### PR TITLE
Feat: DB에서 강의정보 가저와서 타입에 따른 강의장 랜더링 기능 구현

### DIFF
--- a/src/components/lecture/typesOf/LinkLecture.tsx
+++ b/src/components/lecture/typesOf/LinkLecture.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from "react";
+import type { LectureContent } from "@/types/firebase.Types";
+
+interface LinkLectureProps {
+  content: LectureContent;
+}
+
+const LinkLecture: FC<LinkLectureProps> = ({ content }) => {
+  const linkKey = content.externalLink.split("v=")[1];
+  const src = `https://www.youtube.com/embed/${linkKey}`;
+
+  return (
+    <div className="linkContainer h-full w-full">
+      <iframe
+        src={src}
+        title="video player"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        className="w-full h-full"
+      />
+    </div>
+  );
+};
+
+export default LinkLecture;

--- a/src/components/lecture/typesOf/NoteLecture.tsx
+++ b/src/components/lecture/typesOf/NoteLecture.tsx
@@ -1,0 +1,24 @@
+import React, { FC } from "react";
+import type { LectureContent } from "@/types/firebase.Types";
+
+interface NoteLectureProps {
+  content: LectureContent;
+}
+
+const NoteLecture: FC<NoteLectureProps> = ({ content }) => {
+  const src = `https://www.youtube.com/embed/${content}`;
+
+  return (
+    <div className="noteContainer h-full w-full">
+      <iframe
+        src={src}
+        title="video player"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        className="w-full h-full"
+      />
+    </div>
+  );
+};
+
+export default NoteLecture;

--- a/src/components/lecture/typesOf/VideoLecture.tsx
+++ b/src/components/lecture/typesOf/VideoLecture.tsx
@@ -1,0 +1,24 @@
+import React, { FC } from "react";
+import type { LectureContent } from "@/types/firebase.Types";
+
+interface VideoLectureProps {
+  content: LectureContent;
+}
+
+const VideoLecture: FC<VideoLectureProps> = ({ content }) => {
+  const src = `https://www.youtube.com/embed/${content}`;
+
+  return (
+    <div className="videoContainer h-full w-full">
+      <iframe
+        src={src}
+        title="video player"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        className="w-full h-full"
+      />
+    </div>
+  );
+};
+
+export default VideoLecture;

--- a/src/hooks/lecture/useGetLectureInfo.tsx
+++ b/src/hooks/lecture/useGetLectureInfo.tsx
@@ -1,0 +1,25 @@
+import type { Lecture, User } from "@/types/firebase.Types";
+import { db } from "@/utils/firebase";
+import { useQuery } from "@tanstack/react-query";
+import { getDoc, doc } from "firebase/firestore";
+
+const fetchLectureInfo = async (docId: string) => {
+  const docRef = doc(db, "lectures", docId);
+  const docSnap = await getDoc(docRef);
+  if (docSnap.exists()) {
+    const userSnap = await getDoc(docSnap.data().userId);
+    const user = userSnap.data() as User;
+    return { ...docSnap.data(), user } as Lecture;
+  }
+  return docSnap.data() as Lecture;
+};
+
+const useGetLectureInfo = (docId: string) => {
+  return useQuery<Lecture>(
+    ["lecture", docId],
+    async () => await fetchLectureInfo(docId),
+    { refetchOnWindowFocus: false },
+  );
+};
+
+export default useGetLectureInfo;

--- a/src/types/firebase.Types.ts
+++ b/src/types/firebase.Types.ts
@@ -1,0 +1,135 @@
+import { Timestamp, DocumentReference } from "firebase/firestore";
+export interface User {
+  id: string;
+  email: string;
+  username: string;
+  role: "수강생" | "관리자";
+  profileImage: string;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+export interface Post {
+  id: string;
+  parentId: string;
+  category: "필독" | "안내사항" | "질문있어요" | "자유게시판" | "익명피드백";
+  user?: User;
+  userId: DocumentReference;
+  title: string;
+  content: string;
+  postImages: string[];
+  thumbnailImages: string[];
+  tags: string[];
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+export interface Course {
+  id: string;
+  title: string;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+export interface Lecture {
+  id: string;
+  user?: User;
+  userId: DocumentReference;
+  course?: Course;
+  courseId: DocumentReference;
+  title: string;
+  isPrivate: boolean;
+  startDate: Timestamp;
+  endDate: Timestamp;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  lectureType: "노트" | "비디오" | "링크";
+  lectureContent: LectureContent;
+}
+
+export interface Progress {
+  id: string;
+  user?: User;
+  userId: DocumentReference;
+  isCompleted: boolean;
+  playTimes: playTime[];
+  lectureId: DocumentReference;
+}
+
+export interface Assignment {
+  id: string;
+  user?: User;
+  userId: DocumentReference;
+  title: string;
+  content: string;
+  level: "상" | "중" | "하";
+  images: string[];
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  startDate: Timestamp;
+  endDate: Timestamp;
+  readStudents: string[];
+}
+
+export interface SubmittedAssignment {
+  id: string;
+  assignment?: Assignment;
+  assignmentId: DocumentReference;
+  user?: User;
+  userId: DocumentReference;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  isRead: boolean;
+  feedbacks: Feedback[];
+}
+
+export interface Attachment {
+  id: string;
+  user?: User;
+  userId: DocumentReference;
+  submittedAssignment?: SubmittedAssignment;
+  submittedAssignmentId: DocumentReference;
+  links: string[];
+  attachmentFiles: AttachmentFile[];
+}
+
+export interface Feedback {
+  id: string;
+  user?: User;
+  userId: DocumentReference;
+  content: string;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+export interface LectureComment {
+  id: string;
+  lecture?: Lecture;
+  lectureId: DocumentReference;
+  parentId: string;
+  user?: User;
+  userId: DocumentReference;
+  content: string;
+  replyCount: number;
+  timestamp: string;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+
+export interface LectureContent {
+  images: string[];
+  textContent: string;
+  externalLink: string;
+  videoUrl: string;
+  videoLength: number;
+}
+
+export interface AttachmentFile {
+  url: string;
+  name: string;
+}
+
+export interface playTime {
+  start: string;
+  end: string;
+}

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -1,6 +1,7 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
+// import { getAnalytics } from "firebase/analytics";
+import { getFirestore } from "firebase/firestore";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -18,4 +19,7 @@ const firebaseConfig = {
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
+// const analytics = getAnalytics(app);
+const db = getFirestore(app);
+
+export { db };


### PR DESCRIPTION
## 개요 :mag:

Firebase의 Firestore에 저장되어 있는 정보를 조회하여 가져온 후,
강의장에 랜더링하는 기능 구현

## 작업사항 :memo:

`이슈 번호를 적어주세요. 해당 PR이 merge되면 닫히는 이슈는 close를 붙여주세요./해당 이슈사항을 해결하기 위해 어떤 작업을 했는지 남겨주세요.`
`ex) close #8 로그인 페이지 버튼 `

close #50 

## 테스트 방법(optional)

`리뷰하는 사람이 어떻게 테스트할 수 있을지 간략히 써주세요.`
