### PR TITLE
Feat: 클래스룸의 모든 모달창 공통 레이아웃 구현

### DIFF
--- a/src/components/classroomModal/common/Layout.tsx
+++ b/src/components/classroomModal/common/Layout.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from "react";
+import { useDispatch } from "react-redux";
+import { closeModal } from "@/redux/slice/classroomModalSlice";
+import Image from "next/image";
+
+interface ModalProps {
+  children: ReactNode;
+}
+
+const Layout: React.FC<ModalProps> = ({ children }) => {
+  const dispatch = useDispatch();
+
+  return (
+    <div
+      className="fixed top-0 left-0 w-screen h-screen bg-black/30 flex flex-col justify-center items-center"
+      onClick={() => dispatch(closeModal())}
+    >
+      <article
+        className="relative w-[770px] bg-white px-8 py-9 flex flex-col gap-5 rounded-[10px] border border-solid border-grayscale-10 drop-shadow-[0_0_8px_rgba(0,0,0,0.25)] box-border"
+        onClick={e => e.stopPropagation()}
+      >
+        {children}
+        <button type="button">
+          <Image
+            src="/images/close.svg"
+            alt="닫기 버튼"
+            width={24}
+            height={24}
+            className="absolute top-9 right-8"
+            onClick={() => dispatch(closeModal())}
+          />
+        </button>
+      </article>
+    </div>
+  );
+};
+
+export default Layout;


### PR DESCRIPTION
## 개요 :mag:
* 클래스룸 페이지에서 사용하는 모든 모달창(댓글관련, 강의추가 관련)의 레이아웃 구현
* 모달창 바깥 영역과 딛기버튼을 클릭하면 모달창이 닫히도록 구현
* 모달창 영역을 클릭하면 모달창이 닫히지 않도록 `stopPropagation` 사용 (버블링 제거)

## 작업사항 :memo:
close #47 

