### PR TITLE
Style: 클래스룸 강의 추가 모달창 공통 컴포넌트 구현

### DIFF
--- a/src/components/classroomModal/common/LectureTitle.tsx
+++ b/src/components/classroomModal/common/LectureTitle.tsx
@@ -1,0 +1,15 @@
+const LectureTitle: React.FC = () => {
+  return (
+    <label htmlFor="lectureTitle">
+      <input
+        type="text"
+        name="lectureTitle"
+        id="lectureTitle"
+        placeholder="제목을 입력해주세요. (필수)"
+        className="text-grayscale-80 outline-none text-xl font-medium placeholder-grayscale-40"
+      />
+    </label>
+  );
+};
+
+export default LectureTitle;

--- a/src/components/classroomModal/common/ModalFooter.tsx
+++ b/src/components/classroomModal/common/ModalFooter.tsx
@@ -1,0 +1,12 @@
+import ModalSubmitButton from "./ModalSubmitButton";
+
+const ModalFooter: React.FC = () => {
+  return (
+    <div className="flex justify-between mb-[-20px]">
+      {/* 이 위치에 수상 기간 및 강의 공개 컴포넌트  */}
+      <ModalSubmitButton />
+    </div>
+  );
+};
+
+export default ModalFooter;

--- a/src/components/classroomModal/common/ModalHeader.tsx
+++ b/src/components/classroomModal/common/ModalHeader.tsx
@@ -1,0 +1,27 @@
+import useClassroomModal from "@/hooks/useClassroomModal";
+import { ReactNode } from "react";
+
+interface ModalHeaderProps {
+  children: ReactNode;
+  currentModalName: string;
+}
+
+const ModalHeader: React.FC<ModalHeaderProps> = ({
+  children,
+  currentModalName,
+}) => {
+  return (
+    <div className="flex gap-[10px] text-xl font-bold text-grayscale-100">
+      {children}
+      {children ? (
+        <span className="relative pl-[17px] before:absolute before:top-[9px] before:left-0 before:w-[7px] before:h-[11px] before:bg-[url('/images/arrow-right.svg')] before:bg-no-repeat">
+          {currentModalName}
+        </span>
+      ) : (
+        <span>{currentModalName}</span>
+      )}
+    </div>
+  );
+};
+
+export default ModalHeader;

--- a/src/components/classroomModal/common/ModalSubmitButton.tsx
+++ b/src/components/classroomModal/common/ModalSubmitButton.tsx
@@ -1,0 +1,12 @@
+const ModalSubmitButton: React.FC = () => {
+  return (
+    <button
+      type="submit"
+      className="w-[107px] h-[45px] rounded-[10px] font-bold text-base text-grayscale-20 bg-grayscale-5 hover:text-white hover:bg-primary-80"
+    >
+      업로드
+    </button>
+  );
+};
+
+export default ModalSubmitButton;


### PR DESCRIPTION
## 개요 :mag:
* `ModalHeader` 컴포넌트 : 자식(children)이 없을 경우 화살표가 없이 모달의 제목만 나오고,   자식(children)이 있을 경우 화살표가 있는 제목이 나오도록 설정
> 예시)
자식(children)이 없는 경우
![image](https://github.com/sniperfactory-official/sfac-lms-team-b/assets/97039896/a259f6d7-c7bd-4f3b-898d-17dd49e0f3af)
자식(children)이 있는 경우
![image](https://github.com/sniperfactory-official/sfac-lms-team-b/assets/97039896/d7327946-9ba6-4949-92f3-00fe78aea233)


* `ModalSubmitButton` 컴포넌트 : 업로드 버튼을 누르면 메인에 있는 내용들(비디오파일, 노트, 링크 등)이 서버에 전송될 수 있도록 버튼 type을 submit으로 설정
* `ModalFooter` 컴포넌트 : 수강기간/강의공개 설정 컴포넌트(예림님이 구현하실 예정)와 `ModalSubmitButton` 컴포넌트를 포함하도록 구현
* `LectureTitle` 컴포넌트 : 각 모달창에서 강의 제목을 입력할 수있도록 구현

## 작업사항 :memo:
close #63 


