### PR TITLE
Feat: 클래스룸 모든 모달창 visibility 상태관리 로직 구현

### DIFF
--- a/src/hooks/lecture/useClassroomModal.tsx
+++ b/src/hooks/lecture/useClassroomModal.tsx
@@ -1,0 +1,45 @@
+import { RootState } from "@/redux/store";
+import { useDispatch, useSelector } from "react-redux";
+import { setModalVisibility } from "@/redux/slice/classroomModalSlice";
+
+const useClassroomModal = () => {
+  const dispatch = useDispatch();
+
+  const lectureTypeModalOpen = useSelector(
+    (state: RootState) => state.classroomModal.lectureTypeModalOpen,
+  );
+  const noteModalOpen = useSelector(
+    (state: RootState) => state.classroomModal.noteModalOpen,
+  );
+  const linkModalOpen = useSelector(
+    (state: RootState) => state.classroomModal.linkModalOpen,
+  );
+  const videoFileModalOpen = useSelector(
+    (state: RootState) => state.classroomModal.videoFileModalOpen,
+  );
+  const commentModalOpen = useSelector(
+    (state: RootState) => state.classroomModal.commentModalOpen,
+  );
+  const replyCommentModalOpen = useSelector(
+    (state: RootState) => state.classroomModal.replyCommentModalOpen,
+  );
+
+  const handleModalMove = (closeModalName: string) => {
+    dispatch(
+      setModalVisibility({ modalName: "lectureTypeModalOpen", visible: true }),
+    );
+    dispatch(setModalVisibility({ modalName: closeModalName, visible: false }));
+  };
+
+  return {
+    lectureTypeModalOpen,
+    noteModalOpen,
+    linkModalOpen,
+    videoFileModalOpen,
+    commentModalOpen,
+    replyCommentModalOpen,
+    handleModalMove,
+  };
+};
+
+export default useClassroomModal;

--- a/src/redux/slice/classroomModalSlice.tsx
+++ b/src/redux/slice/classroomModalSlice.tsx
@@ -1,0 +1,38 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface ModalState {
+  lectureTypeModalOpen: boolean;
+  noteModalOpen: boolean;
+  linkModalOpen: boolean;
+  videoFileModalOpen: boolean;
+  commentModalOpen: boolean;
+  replyCommentModalOpen: boolean;
+  [key: string]: boolean;
+}
+
+const initialState: ModalState = {
+  lectureTypeModalOpen: false,
+  noteModalOpen: false,
+  linkModalOpen: false,
+  videoFileModalOpen: false,
+  commentModalOpen: false,
+  replyCommentModalOpen: false,
+};
+
+const classroomModalSlice = createSlice({
+  name: "classroomModal",
+  initialState,
+  reducers: {
+    setModalVisibility: (
+      state,
+      action: PayloadAction<{ modalName: string; visible: boolean }>,
+    ) => {
+      const { modalName, visible } = action.payload;
+      state[modalName] = visible;
+    },
+    closeModal: () => initialState,
+  },
+});
+
+export const { setModalVisibility, closeModal } = classroomModalSlice.actions;
+export default classroomModalSlice.reducer;

--- a/src/redux/store.tsx
+++ b/src/redux/store.tsx
@@ -1,0 +1,13 @@
+import { configureStore } from "@reduxjs/toolkit";
+import classroomModalReducer from "./slice/classroomModalSlice";
+
+export const store = configureStore({
+  reducer: {
+    classroomModal: classroomModalReducer,
+  },
+  devTools: process.env.NODE_ENV !== "production",
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
## 개요 :mag:
* 클래스룸 모달창의 open/close 상태를 관리하기 위한 리덕스 툴킷 slice 구현
* 클래스룸 모달창의 open/close 상태를 체크 및 변경하기 위한 커스텀 훅 구현

## 작업사항 :memo:
close #14 

