### PR TITLE
 Fix: 이미지 파일 변경 및 모달 header 컴포넌트에 선택적 프로퍼티 적용

### DIFF
--- a/public/images/arrow-right.svg
+++ b/public/images/arrow-right.svg
@@ -1,3 +1,3 @@
-<svg width="15" height="15" viewBox="0 0 7 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="7" height="10" viewBox="0 0 7 10" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M6.23828 4.99992L0.0595699 9.82113L0.0595703 0.178705L6.23828 4.99992Z" fill="#999999"/>
 </svg>

--- a/src/components/classroomModal/common/ModalHeader.tsx
+++ b/src/components/classroomModal/common/ModalHeader.tsx
@@ -1,8 +1,7 @@
-import useClassroomModal from "@/hooks/useClassroomModal";
 import { ReactNode } from "react";
 
 interface ModalHeaderProps {
-  children: ReactNode;
+  children?: ReactNode;
   currentModalName: string;
 }
 
@@ -14,7 +13,7 @@ const ModalHeader: React.FC<ModalHeaderProps> = ({
     <div className="flex gap-[10px] text-xl font-bold text-grayscale-100">
       {children}
       {children ? (
-        <span className="relative pl-[17px] before:absolute before:top-[9px] before:left-0 before:w-[7px] before:h-[11px] before:bg-[url('/images/arrow-right.svg')] before:bg-no-repeat">
+        <span className="relative pl-[17px] before:absolute before:top-[9px] before:left-0 before:w-[7px] before:h-[11px] before:bg-[url('/images/arrow-right.svg')] before:bg-no-repeat before:bg-contain">
           {currentModalName}
         </span>
       ) : (

--- a/src/hooks/lecture/useClassroomModal.tsx
+++ b/src/hooks/lecture/useClassroomModal.tsx
@@ -24,9 +24,9 @@ const useClassroomModal = () => {
     (state: RootState) => state.classroomModal.replyCommentModalOpen,
   );
 
-  const handleModalMove = (closeModalName: string) => {
+  const handleModalMove = (openModalName: string, closeModalName: string) => {
     dispatch(
-      setModalVisibility({ modalName: "lectureTypeModalOpen", visible: true }),
+      setModalVisibility({ modalName: openModalName, visible: true }),
     );
     dispatch(setModalVisibility({ modalName: closeModalName, visible: false }));
   };

--- a/src/hooks/lecture/useClassroomModal.tsx
+++ b/src/hooks/lecture/useClassroomModal.tsx
@@ -25,9 +25,7 @@ const useClassroomModal = () => {
   );
 
   const handleModalMove = (openModalName: string, closeModalName: string) => {
-    dispatch(
-      setModalVisibility({ modalName: openModalName, visible: true }),
-    );
+    dispatch(setModalVisibility({ modalName: openModalName, visible: true }));
     dispatch(setModalVisibility({ modalName: closeModalName, visible: false }));
   };
 


### PR DESCRIPTION
## 개요 :mag:
* 오른쪽 화살표 이미지 파일의 사이즈가 원본과 달라 디자인에 영향을 주어서 원본 이미지로 파일 교체
* `ModalHeader` 컴포넌트에서 `children` props를 선택적 프로퍼티로 변경하여 
`children`이 없을때 생기는 문제 해결
* `useClassroomModal` 커스텀 훅에서 `handleModalMove` 함수 수정

## 작업사항 :memo:
close #70 
