### PR TITLE
Refactor: 유저정보 분기처리 및 코드 가독성 개선, 전체과제 이동버튼 활성화

### DIFF
--- a/src/app/assignment/components/LeftNav.tsx
+++ b/src/app/assignment/components/LeftNav.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import CreateAssignments from "./CreateAssignments";
 import Modal from "./Modal";
 import Link from "next/link";
-import LeftNavContent from "./LeftNavContent"
+import LeftNavContent from "./LeftNavContent";
 
 const USER_INFO = {
   id: 1,
@@ -12,60 +12,65 @@ const USER_INFO = {
   username: "김지은",
 };
 
-const LeftNav = ()=>{
+const LeftNav = () => {
   const [isLinkOpen, setIsLinkOpen] = useState(false);
 
   return (
     <div className="float-left mr-[30px]">
       <div className="w-[245px] p-[13px] rounded-xl bg-[#f5f8ff] ">
-        <Link 
-            href="/assignment/list">
-            <img
-              className="inline align-middle mr-1"
-              src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
-              alt="error"
-              width="19" />
-            전체과제
+        <Link href="/assignment/list">
+          <img
+            className="inline align-middle mr-1"
+            src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
+            alt="error"
+            width="19"
+          />
+          전체과제
         </Link>
       </div>
       <LeftNavContent />
-      {
-        USER_INFO.role === "관리자" ? (
-          <div>
-            <div className="flex justify-center items-center w-[246px] h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
-              <button
-                type="button"
-                onClick={()=>{
-                  setIsLinkOpen(true);
-                }}>
-                <img
-                  className="inline align-middle"
-                  src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
-                  alt="error" />
-                과제 만들기
-              </button>
-            </div>
-            <Modal
-              title="과제만들기"
-              isOpen={isLinkOpen}
-              onClose={()=>{
-                setIsLinkOpen(false);
-              }}>
-              <CreateAssignments />
-            </Modal>
-            <div className="flex justify-center items-center w-[246px] h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
-              <button type='button'>
-                <img
-                  className="inline align-middle"
-                  src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
-                  alt="error" />
-                순서 변경
-              </button>
-            </div>
+      {USER_INFO.role === "관리자" ? (
+        <div>
+          <div className="flex justify-center items-center w-[246px] h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
+            <button
+              type="button"
+              onClick={() => {
+                setIsLinkOpen(true);
+              }}
+            >
+              <img
+                className="inline align-middle"
+                src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
+                alt="error"
+              />
+              과제 만들기
+            </button>
           </div>
-      ) : "" }
+          <Modal
+            title="과제만들기"
+            isOpen={isLinkOpen}
+            onClose={() => {
+              setIsLinkOpen(false);
+            }}
+          >
+            <CreateAssignments />
+          </Modal>
+          <div className="flex justify-center items-center w-[246px] h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
+            <button type="button">
+              <img
+                className="inline align-middle"
+                src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
+                alt="error"
+              />
+              순서 변경
+            </button>
+          </div>
+        </div>
+      ) : (
+        ""
+      )}
     </div>
-  )
+  );
 };
 
 export default LeftNav;

--- a/src/app/assignment/components/LeftNav.tsx
+++ b/src/app/assignment/components/LeftNav.tsx
@@ -3,70 +3,69 @@
 import React, { useState } from "react";
 import CreateAssignments from "./CreateAssignments";
 import Modal from "./Modal";
+import Link from "next/link";
+import LeftNavContent from "./LeftNavContent"
 
-const LeftNav = () => {
+const USER_INFO = {
+  id: 1,
+  role: "관리자", // 관리자, 수강생
+  username: "김지은",
+};
+
+const LeftNav = ()=>{
   const [isLinkOpen, setIsLinkOpen] = useState(false);
 
   return (
     <div className="float-left mr-[30px]">
       <div className="w-[245px] p-[13px] rounded-xl bg-[#f5f8ff] ">
-        <a href="#">
-          <img
-            className="inline align-middle mr-1"
-            src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
-            alt="멍멍"
-            width="19px"
-          />
-          전체과제
-        </a>
+        <Link 
+            href="/assignment/list">
+            <img
+              className="inline align-middle mr-1"
+              src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
+              alt="error"
+              width="19" />
+            전체과제
+        </Link>
       </div>
-      <div>
-        <li className="list-none w-[245px] p-[10px]">
-          <a href="#">HTTP 리퀘스트 보내기</a>
-        </li>
-        <li className="list-none w-[245px] p-[10px]">
-          <a href="#">ListTile 커스텀 위젯 만들기</a>
-        </li>
-        <li className="list-none w-[245px] p-[10px]">
-          <a href="#">ListTile 커스텀 위젯 만들기</a>
-        </li>
-      </div>
-      <div className="flex justify-center items-center w-[246px] h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
-        <a
-          href="#"
-          onClick={() => {
-            setIsLinkOpen(true);
-          }}
-        >
-          <img
-            className="inline align-middle"
-            src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
-            alt="멍멍"
-          />
-          과제 만들기
-        </a>
-      </div>
-      <Modal
-        title="과제만들기"
-        isOpen={isLinkOpen}
-        onClose={() => {
-          setIsLinkOpen(false);
-        }}
-      >
-        <CreateAssignments />
-      </Modal>
-      <div className="flex justify-center items-center w-[246px] h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
-        <a href="#">
-          <img
-            className="inline align-middle"
-            src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
-            alt="멍멍"
-          />
-          순서 변경
-        </a>
-      </div>
+      <LeftNavContent />
+      {
+        USER_INFO.role === "관리자" ? (
+          <div>
+            <div className="flex justify-center items-center w-[246px] h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
+              <button
+                type="button"
+                onClick={()=>{
+                  setIsLinkOpen(true);
+                }}>
+                <img
+                  className="inline align-middle"
+                  src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
+                  alt="error" />
+                과제 만들기
+              </button>
+            </div>
+            <Modal
+              title="과제만들기"
+              isOpen={isLinkOpen}
+              onClose={()=>{
+                setIsLinkOpen(false);
+              }}>
+              <CreateAssignments />
+            </Modal>
+            <div className="flex justify-center items-center w-[246px] h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
+              <button type='button'>
+                <img
+                  className="inline align-middle"
+                  src="https://interactive-examples.mdn.mozilla.net/media/examples/star2.png"
+                  alt="error" />
+                순서 변경
+              </button>
+            </div>
+          </div>
+      ) : "" }
     </div>
-  );
+  )
 };
 
 export default LeftNav;

--- a/src/app/assignment/components/LeftNavContent.tsx
+++ b/src/app/assignment/components/LeftNavContent.tsx
@@ -1,29 +1,32 @@
-"use client"
+"use client";
 
 import React from "react";
 import Link from "next/link";
 import { Assignment } from "@/types/firebase.types";
 import { useGetAssignment } from "@hooks/queries/useGetAssignment";
 
-interface AssignmentNumberAdded extends Assignment{
+interface AssignmentNumberAdded extends Assignment {
   assignmentNumber: number;
 }
 
-const LeftNavContent = ()=>{
+const LeftNavContent = () => {
   const assignmentData = useGetAssignment("");
 
-  if (assignmentData.isLoading === false){
-    const assignment = assignmentData.data
-    const htmlContent = assignment?.map((assign: AssignmentNumberAdded)=>(
-        <li key={assign.assignmentNumber} className="list-none w-[245px] p-[10px]">
-          <Link href={'/assignment/detail/'+assign.assignmentNumber}>
-              {assign.title}
-          </Link>
-        </li>
+  if (assignmentData.isLoading === false) {
+    const assignment = assignmentData.data;
+    const htmlContent = assignment?.map((assign: AssignmentNumberAdded) => (
+      <li
+        key={assign.assignmentNumber}
+        className="list-none w-[245px] p-[10px]"
+      >
+        <Link href={"/assignment/detail/" + assign.assignmentNumber}>
+          {assign.title}
+        </Link>
+      </li>
     ));
 
-  return htmlContent
+    return htmlContent;
   }
 };
 
-export default LeftNavContent
+export default LeftNavContent;

--- a/src/app/assignment/components/LeftNavContent.tsx
+++ b/src/app/assignment/components/LeftNavContent.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import React from "react";
+import Link from "next/link";
+import { Assignment } from "@/types/firebase.types";
+import { useGetAssignment } from "@hooks/queries/useGetAssignment";
+
+interface AssignmentNumberAdded extends Assignment{
+  assignmentNumber: number;
+}
+
+const LeftNavContent = ()=>{
+  const assignmentData = useGetAssignment("");
+
+  if (assignmentData.isLoading === false){
+    const assignment = assignmentData.data
+    const htmlContent = assignment?.map((assign: AssignmentNumberAdded)=>(
+        <li key={assign.assignmentNumber} className="list-none w-[245px] p-[10px]">
+          <Link href={'/assignment/detail/'+assign.assignmentNumber}>
+              {assign.title}
+          </Link>
+        </li>
+    ));
+
+  return htmlContent
+  }
+};
+
+export default LeftNavContent

--- a/src/app/assignment/components/ListContent.tsx
+++ b/src/app/assignment/components/ListContent.tsx
@@ -1,48 +1,55 @@
 "use client";
 
-//. 0728 ReactQuery로 데이터 불러오기
 import React from "react";
-import { useGetAssignment } from "../../../hooks/queries/useGetAssignment";
-import { DocumentData } from "firebase/firestore";
+import { useGetAssignment } from '@hooks/queries/useGetAssignment';
 import { Assignment } from "@/types/firebase.types";
 import Link from "next/link";
 
-interface Assignment2 extends Assignment {
+interface AssignmentNumberAdded extends Assignment{
   assignmentNumber: number;
 }
 
-const ListContent = () => {
-  const assignDat = useGetAssignment("");
-  let cont;
-  if (assignDat.isLoading === false) {
-    //_데이터 정의
-    const assignment = assignDat.data;
-    console.log(assignment);
-    //_매핑
-    cont = assignment?.map((assign: Assignment2) => (
+const USER_INFO = {
+  id: 1,
+  role: "관리자", // 관리자, 수강생
+  username: "김지은",
+};
+
+const ListContent = ()=>{
+  const assignmentData = useGetAssignment("");
+  let htmlContent ;
+
+  if (assignmentData.isLoading === false){
+    const assignmentInfo = assignmentData.data;
+    htmlContent = assignmentInfo?.map((assign: AssignmentNumberAdded)=>(
       <div
         key={assign.assignmentNumber}
-        className="wrap w-[775px] h-[87px] flex-shrink-0 border-radius-[10px] mb-[20px] border border-grayscale-5 bg-grayscale-0 flex justify-between items-center px-[24px]"
-      >
-        <div className="left flex w-[244px] flex-col items-start gap-[10px]">
-          <div className="tag inline-flex p-[4px] px-[10px] justify-center items-center gap-[8px] rounded-[4px] bg-grayscale-5">
+        className="w-[775px] h-[87px] flex-shrink-0 border-radius-[10px] mb-[20px] border border-grayscale-5 bg-grayscale-0 flex justify-between items-center px-[24px]">
+        <div className="flex w-[244px] flex-col items-start gap-[10px]">
+          <div className="inline-flex p-[4px] px-[10px] justify-center items-center gap-[8px] rounded-[4px] bg-grayscale-5">
             {assign.level}
           </div>
-          <div className="title text-grayscale-80 font-bold text-[16px]">
+          <div className="text-grayscale-80 font-bold text-[16px]">
             {assign.title}
           </div>
         </div>
-        <Link
-          href={"/assignment/detail/" + assign.assignmentNumber}
-          type="button"
-          className="btn w-[157px] h-[35px] p-[9px] gap-[10px] flex justify-center items-center flex-shrink-0 rounded-[10px] bg-primary-80 border-none"
-        >
-          확인하기
-        </Link>
+        { USER_INFO.role === "관리자" ? (
+            <Link
+              href={"/assignment/detail/"+assign.assignmentNumber}
+              className="w-[157px] h-[35px] p-[9px] gap-[10px] flex justify-center items-center flex-shrink-0 rounded-[10px] bg-primary-80 border-none">
+              확인하기
+            </Link>
+          ):(
+            <Link
+            href={"/assignment/detail/"+assign.assignmentNumber}
+            className="w-[157px] h-[35px] p-[9px] gap-[10px] flex justify-center items-center flex-shrink-0 rounded-[10px] bg-primary-80 border-none">
+              제출하기
+            </Link>
+          ) }
       </div>
-    ));
-  }
-  return <div>{cont}</div>;
+    ));}
+
+  return <div>{htmlContent}</div>;
 };
 
 export default ListContent;

--- a/src/app/assignment/components/ListContent.tsx
+++ b/src/app/assignment/components/ListContent.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import React from "react";
-import { useGetAssignment } from '@hooks/queries/useGetAssignment';
+import { useGetAssignment } from "@hooks/queries/useGetAssignment";
 import { Assignment } from "@/types/firebase.types";
 import Link from "next/link";
 
-interface AssignmentNumberAdded extends Assignment{
+interface AssignmentNumberAdded extends Assignment {
   assignmentNumber: number;
 }
 
@@ -15,16 +15,17 @@ const USER_INFO = {
   username: "김지은",
 };
 
-const ListContent = ()=>{
+const ListContent = () => {
   const assignmentData = useGetAssignment("");
-  let htmlContent ;
+  let htmlContent;
 
-  if (assignmentData.isLoading === false){
+  if (assignmentData.isLoading === false) {
     const assignmentInfo = assignmentData.data;
-    htmlContent = assignmentInfo?.map((assign: AssignmentNumberAdded)=>(
+    htmlContent = assignmentInfo?.map((assign: AssignmentNumberAdded) => (
       <div
         key={assign.assignmentNumber}
-        className="w-[775px] h-[87px] flex-shrink-0 border-radius-[10px] mb-[20px] border border-grayscale-5 bg-grayscale-0 flex justify-between items-center px-[24px]">
+        className="w-[775px] h-[87px] flex-shrink-0 border-radius-[10px] mb-[20px] border border-grayscale-5 bg-grayscale-0 flex justify-between items-center px-[24px]"
+      >
         <div className="flex w-[244px] flex-col items-start gap-[10px]">
           <div className="inline-flex p-[4px] px-[10px] justify-center items-center gap-[8px] rounded-[4px] bg-grayscale-5">
             {assign.level}
@@ -33,21 +34,24 @@ const ListContent = ()=>{
             {assign.title}
           </div>
         </div>
-        { USER_INFO.role === "관리자" ? (
-            <Link
-              href={"/assignment/detail/"+assign.assignmentNumber}
-              className="w-[157px] h-[35px] p-[9px] gap-[10px] flex justify-center items-center flex-shrink-0 rounded-[10px] bg-primary-80 border-none">
-              확인하기
-            </Link>
-          ):(
-            <Link
-            href={"/assignment/detail/"+assign.assignmentNumber}
-            className="w-[157px] h-[35px] p-[9px] gap-[10px] flex justify-center items-center flex-shrink-0 rounded-[10px] bg-primary-80 border-none">
-              제출하기
-            </Link>
-          ) }
+        {USER_INFO.role === "관리자" ? (
+          <Link
+            href={"/assignment/detail/" + assign.assignmentNumber}
+            className="w-[157px] h-[35px] p-[9px] gap-[10px] flex justify-center items-center flex-shrink-0 rounded-[10px] bg-primary-80 border-none"
+          >
+            확인하기
+          </Link>
+        ) : (
+          <Link
+            href={"/assignment/detail/" + assign.assignmentNumber}
+            className="w-[157px] h-[35px] p-[9px] gap-[10px] flex justify-center items-center flex-shrink-0 rounded-[10px] bg-primary-80 border-none"
+          >
+            제출하기
+          </Link>
+        )}
       </div>
-    ));}
+    ));
+  }
 
   return <div>{htmlContent}</div>;
 };

--- a/src/app/assignment/list/page.tsx
+++ b/src/app/assignment/list/page.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import ListContent from "../components/ListContent";
 
-const List = ()=>{
+const List = () => {
   return (
     <div>
       <ListContent />

--- a/src/app/assignment/list/page.tsx
+++ b/src/app/assignment/list/page.tsx
@@ -1,9 +1,9 @@
-import React from "react";
-import ListContent from "../components/ListContent";
 "use client";
 
-//.0726 : 기본 레이아웃 설정
-const List = () => {
+import React from "react";
+import ListContent from "../components/ListContent";
+
+const List = ()=>{
   return (
     <div>
       <ListContent />


### PR DESCRIPTION
## 개요 :mag:

`유저정보 분기처리 및 코드 가독성 개선, 전체과제 이동버튼 활성화`

## 작업사항 :memo:

`Close #32 ` 
`Close #33 ` 
`Close #36 `

## 테스트 방법(optional)

1. 버튼을 눌러가며 테스트
2. `ListContent` 와 `LeftNav` 파일 상단에 `USER_INFO`를 정의해놓았습니다.
테스트 시 해당 객체의 정보를 바꿔가며 분기테스트 하시면 됩니다!

※ 과제순서변경 버튼은 아직 활성화되지 않았습니다.(추후 개발예정)
