### PR TITLE
Feat: 답글 기능 구현 및 삭제 기능 구현

### DIFF
--- a/src/components/classroomModal/comment/Comment.tsx
+++ b/src/components/classroomModal/comment/Comment.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import Image from "next/image";
 import { DocumentData } from "firebase/firestore";
 import React from "react";

--- a/src/components/classroomModal/comment/Comment.tsx
+++ b/src/components/classroomModal/comment/Comment.tsx
@@ -81,7 +81,10 @@ const Comment: React.FC<CommentProps> = ({
                   수정
                 </li>
                 <li>|</li>
-                <li className="text-black hover:text-red cursor-pointer" onClick={handleDeleteClick}>
+                <li
+                  className="text-black hover:text-red cursor-pointer"
+                  onClick={handleDeleteClick}
+                >
                   삭제
                 </li>
               </ul>

--- a/src/components/classroomModal/comment/Comment.tsx
+++ b/src/components/classroomModal/comment/Comment.tsx
@@ -3,6 +3,7 @@ import { DocumentData } from "firebase/firestore";
 import React from "react";
 import { getTime } from "@/utils/getTime";
 import useAuth from "@/hooks/user/useAuth";
+import { useDeleteComment } from "@/hooks/lecture/useDeleteComment";
 
 interface CommentProps {
   comment: DocumentData;
@@ -23,6 +24,8 @@ const Comment: React.FC<CommentProps> = ({
 
   const user = useAuth();
 
+  const deleteMutation = useDeleteComment();
+
   const displayedComment =
     !showFullComment && content.length > 10
       ? `${content.slice(0, 10)}...`
@@ -35,6 +38,12 @@ const Comment: React.FC<CommentProps> = ({
       onCommentClick(id);
     }
   };
+
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    deleteMutation.mutate(id);
+  };
+
   return (
     <div className="flex items-start space-x-2 w-full h-30">
       {isReply && (
@@ -72,7 +81,7 @@ const Comment: React.FC<CommentProps> = ({
                   수정
                 </li>
                 <li>|</li>
-                <li className="text-black hover:text-red cursor-pointer">
+                <li className="text-black hover:text-red cursor-pointer" onClick={handleDeleteClick}>
                   삭제
                 </li>
               </ul>

--- a/src/components/classroomModal/comment/CommentForm.tsx
+++ b/src/components/classroomModal/comment/CommentForm.tsx
@@ -1,26 +1,27 @@
 import React, { FC, useState, ChangeEvent, FormEvent } from "react";
 import useAuth from "@/hooks/user/useAuth";
 import useUsername from "@/hooks/user/useUserName";
-import { RootState } from "@/redux/store";
-import { useSelector } from "react-redux/es/hooks/useSelector";
 import { useAddCommentMutation } from "@/hooks/lecture/useAddCommentMutation";
 
-const CommentForm: FC = () => {
+interface CommentFormProps {
+  parentId?: string;
+  lectureId: string;
+}
+
+const CommentForm: FC<CommentFormProps> = ({ parentId = "", lectureId }) => {
   const [comment, setComment] = useState("");
   const user = useAuth();
   const username = useUsername(user?.uid ?? null);
-  const lectureId = useSelector(
-    (state: RootState) => state.classroomModal.lectureId,
-  );
   const mutation = useAddCommentMutation();
-
+  
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    console.log(lectureId);
     if (user && lectureId) {
       mutation.mutate({
         content: comment,
         lectureId: lectureId,
-        parentId: "",
+        parentId: parentId,
         userId: user.uid,
       });
       setComment("");

--- a/src/components/classroomModal/comment/CommentForm.tsx
+++ b/src/components/classroomModal/comment/CommentForm.tsx
@@ -13,7 +13,7 @@ const CommentForm: FC<CommentFormProps> = ({ parentId = "", lectureId }) => {
   const user = useAuth();
   const username = useUsername(user?.uid ?? null);
   const mutation = useAddCommentMutation();
-  
+
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     console.log(lectureId);

--- a/src/components/classroomModal/comment/ReplySection.tsx
+++ b/src/components/classroomModal/comment/ReplySection.tsx
@@ -1,6 +1,5 @@
-import React, { FC, useState, useEffect } from "react";
+import React, { FC } from "react";
 
-import { DocumentData } from "firebase/firestore";
 import CommentForm from "./CommentForm";
 import Comment from "./Comment";
 import Layout from "../common/Layout";
@@ -9,9 +8,10 @@ import useGetComments from "@/hooks/lecture/useGetComments";
 
 interface ReplySectionProps {
   commentId: string;
+  lectureId: string;
 }
 
-const ReplySection: FC<ReplySectionProps> = ({ commentId }) => {
+const ReplySection: FC<ReplySectionProps> = ({ commentId, lectureId }) => {
   const { replyCommentModalOpen } = useClassroomModal();
   const { data: comment } = useGetComments(undefined, undefined, commentId);
   const { data: replies } = useGetComments(undefined, commentId, undefined);
@@ -35,7 +35,7 @@ const ReplySection: FC<ReplySectionProps> = ({ commentId }) => {
               </li>
             ))}
         </ul>
-        <CommentForm />
+        <CommentForm parentId={commentId} lectureId={lectureId} />
       </Layout>
     )
   );

--- a/src/components/lectureRoom/CommentsSection.tsx
+++ b/src/components/lectureRoom/CommentsSection.tsx
@@ -8,11 +8,13 @@ import { DocumentData } from "firebase/firestore";
 interface CommentsSectionProps {
   comments: DocumentData[] | undefined;
   onCommentClick: (id: string) => void;
+  lectureId: string;
 }
 
 const CommentsSection: FC<CommentsSectionProps> = ({
   comments = [],
   onCommentClick,
+  lectureId
 }) => {
   const { commentModalOpen } = useClassroomModal();
 
@@ -29,7 +31,7 @@ const CommentsSection: FC<CommentsSectionProps> = ({
       {commentModalOpen && (
         <Layout>
           <h2 className="text-xl font-bold">댓글 달기</h2>
-          <CommentForm />
+          <CommentForm lectureId={lectureId} />
         </Layout>
       )}
     </ul>

--- a/src/components/lectureRoom/CommentsSection.tsx
+++ b/src/components/lectureRoom/CommentsSection.tsx
@@ -14,7 +14,7 @@ interface CommentsSectionProps {
 const CommentsSection: FC<CommentsSectionProps> = ({
   comments = [],
   onCommentClick,
-  lectureId
+  lectureId,
 }) => {
   const { commentModalOpen } = useClassroomModal();
 

--- a/src/components/lectureRoom/LectureComment.tsx
+++ b/src/components/lectureRoom/LectureComment.tsx
@@ -1,9 +1,6 @@
 import React, { FC, useState } from "react";
 import { useDispatch } from "react-redux";
-import {
-  setModalVisibility,
-  setLectureId,
-} from "@/redux/slice/classroomModalSlice";
+import { setModalVisibility } from "@/redux/slice/classroomModalSlice";
 import ReplySection from "@/components/classroomModal/comment/ReplySection";
 import CommentsSection from "@/components/lectureRoom/CommentsSection";
 import useGetComments from "@/hooks/lecture/useGetComments";
@@ -27,7 +24,6 @@ const LectureComment: FC<LectureCommentProps> = ({ lectureId }) => {
   };
 
   const handleButtonClick = () => {
-    dispatch(setLectureId(lectureId));
     dispatch(
       setModalVisibility({ modalName: "commentModalOpen", visible: true }),
     );
@@ -49,8 +45,14 @@ const LectureComment: FC<LectureCommentProps> = ({ lectureId }) => {
         </button>
       </header>
       <main>
-        <CommentsSection comments={data} onCommentClick={handleCommentClick} />
-        {selectedCommentId && <ReplySection commentId={selectedCommentId} />}
+        <CommentsSection
+          comments={data}
+          onCommentClick={handleCommentClick}
+          lectureId={lectureId}
+        />
+        {selectedCommentId && (
+          <ReplySection commentId={selectedCommentId} lectureId={lectureId} />
+        )}
       </main>
     </section>
   );

--- a/src/hooks/lecture/useDeleteComment.tsx
+++ b/src/hooks/lecture/useDeleteComment.tsx
@@ -1,15 +1,25 @@
 import { useMutation } from "@tanstack/react-query";
 import { db } from "@/utils/firebase";
-import { collection, doc, deleteDoc, query, where, getDocs } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  deleteDoc,
+  query,
+  where,
+  getDocs,
+} from "firebase/firestore";
 
 const deleteCommentFromDB = async (commentId: string) => {
   const commentRef = doc(db, "lectureComments", commentId);
-  
+
   await deleteDoc(commentRef);
 
-  const repliesQuery = query(collection(db, "lectureComments"), where("parentId", "==", commentId));
+  const repliesQuery = query(
+    collection(db, "lectureComments"),
+    where("parentId", "==", commentId),
+  );
   const repliesSnapshot = await getDocs(repliesQuery);
-  repliesSnapshot.forEach((reply) => {
+  repliesSnapshot.forEach(reply => {
     deleteDoc(reply.ref);
   });
 };

--- a/src/hooks/lecture/useDeleteComment.tsx
+++ b/src/hooks/lecture/useDeleteComment.tsx
@@ -1,0 +1,19 @@
+import { useMutation } from "@tanstack/react-query";
+import { db } from "@/utils/firebase";
+import { collection, doc, deleteDoc, query, where, getDocs } from "firebase/firestore";
+
+const deleteCommentFromDB = async (commentId: string) => {
+  const commentRef = doc(db, "lectureComments", commentId);
+  
+  await deleteDoc(commentRef);
+
+  const repliesQuery = query(collection(db, "lectureComments"), where("parentId", "==", commentId));
+  const repliesSnapshot = await getDocs(repliesQuery);
+  repliesSnapshot.forEach((reply) => {
+    deleteDoc(reply.ref);
+  });
+};
+
+export const useDeleteComment = () => {
+  return useMutation(deleteCommentFromDB);
+};

--- a/src/redux/slice/classroomModalSlice.tsx
+++ b/src/redux/slice/classroomModalSlice.tsx
@@ -36,6 +36,5 @@ const classroomModalSlice = createSlice({
   },
 });
 
-export const { setModalVisibility, closeModal } =
-  classroomModalSlice.actions;
+export const { setModalVisibility, closeModal } = classroomModalSlice.actions;
 export default classroomModalSlice.reducer;

--- a/src/redux/slice/classroomModalSlice.tsx
+++ b/src/redux/slice/classroomModalSlice.tsx
@@ -32,13 +32,10 @@ const classroomModalSlice = createSlice({
       const { modalName, visible } = action.payload;
       state[modalName] = visible;
     },
-    setLectureId: (state, action: PayloadAction<string | null>) => {
-      state.lectureId = action.payload;
-    },
     closeModal: () => initialState,
   },
 });
 
-export const { setModalVisibility, setLectureId, closeModal } =
+export const { setModalVisibility, closeModal } =
   classroomModalSlice.actions;
 export default classroomModalSlice.reducer;


### PR DESCRIPTION
## 개요 :mag:

답글 기능 구현. 댓글에 답글을 작성하면 답글이 작성이 됨.
추가적으로 이전에는 redux를 통해 데이터 관리를 했지만, props로 관리를 바꿈
그에 따른 redux에서 관련한 코드 삭제.

추가적으로 댓글과 답글을 삭제하는 기능도 추가
댓글을 삭제할 경우 함께 딸린 답글들도 전부 삭제

## 작업사항 :memo:

close #114 

## 테스트 방법(optional)


