### PR TITLE
Feat: 클래스룸의 강의수정/강의추가 모달창 리팩토링 및 toast 메세지창 렌더링 구현

### DIFF
--- a/public/images/dropzone-border.svg
+++ b/public/images/dropzone-border.svg
@@ -1,0 +1,3 @@
+<svg width="700" height="300" viewBox="0 0 700 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.5" y="0.5" width="699" height="299" rx="9.5" fill="white" stroke="#CCCCCC" stroke-dasharray="10 10"/>
+</svg>

--- a/src/components/classroomModal/createLecture/AddVideoFileModal.tsx
+++ b/src/components/classroomModal/createLecture/AddVideoFileModal.tsx
@@ -27,28 +27,30 @@ const AddVideoFileModal: React.FC = () => {
         </button>
       </ModalHeader>
       <LectureTitle />
-      {videoFile && (
-        <div className="flex gap-3 items-center">
-          <Image
-            src={"/images/file-icon.svg"}
-            alt={"파일 아이콘"}
-            width={0}
-            height={0}
-            className="w-9 h-auto"
-          />
-          <span className="font-bold text-base text-primary-80">
-            {videoFile?.name}
-          </span>
-          <button
-            type="button"
-            className="ml-auto text-xs text-grayscale-100 hover:font-bold"
-            onClick={handleRemoveVideoFile}
-          >
-            삭제
-          </button>
-        </div>
-      )}
-      <DropzoneSection setVideoFile={setVideoFile} />
+      <div className="flex flex-col gap-5 h-72">
+        {videoFile?.type.includes("video") && (
+          <div className="flex gap-3 items-center">
+            <Image
+              src={"/images/file-icon.svg"}
+              alt={"파일 아이콘"}
+              width={0}
+              height={0}
+              className="w-9 h-auto"
+            />
+            <span className="font-bold text-base text-primary-80">
+              {videoFile?.name}
+            </span>
+            <button
+              type="button"
+              className="ml-auto text-xs text-grayscale-100 hover:font-bold"
+              onClick={handleRemoveVideoFile}
+            >
+              삭제
+            </button>
+          </div>
+        )}
+        <DropzoneSection setVideoFile={setVideoFile} />
+      </div>
       <ModalFooter />
     </Layout>
   );

--- a/src/components/classroomModal/createLecture/AddVideoFileModal.tsx
+++ b/src/components/classroomModal/createLecture/AddVideoFileModal.tsx
@@ -1,19 +1,44 @@
-import { useState } from "react";
+import { useEffect } from "react";
+import { RootState } from "@/redux/store";
+import { useDispatch, useSelector } from "react-redux";
 import Image from "next/image";
 import Layout from "../common/Layout";
 import ModalHeader from "../common/ModalHeader";
 import LectureTitle from "../common/LectureTitle";
 import DropzoneSection from "./DropzoneSection";
 import ModalFooter from "../common/ModalFooter";
+import PageToast from "@/components/PageToast";
 import useClassroomModal from "@/hooks/lecture/useClassroomModal";
 import useVideoFileDrop from "@/hooks/lecture/useVideoFileDrop";
+import {
+  setErrorMessage,
+  setSuccessMessage,
+} from "@/redux/slice/dropzoneFileSlice";
 
 const AddVideoFileModal: React.FC = () => {
-  const [videoFile, setVideoFile] = useState<File | null>(null);
+  const dispatch = useDispatch();
+  const videoFile = useSelector(
+    (state: RootState) => state.dropzoneFile.videoFile,
+  );
+  const errorMessage = useSelector(
+    (state: RootState) => state.dropzoneFile.errorMessage,
+  );
+  const successMessage = useSelector(
+    (state: RootState) => state.dropzoneFile.successMessage,
+  );
   const { handleModalMove } = useClassroomModal();
-  const { handleRemoveVideoFile } = useVideoFileDrop({
-    setVideoFile: setVideoFile,
-  });
+  const { handleRemoveVideoFile } = useVideoFileDrop();
+
+  useEffect(() => {
+    if (videoFile) {
+      dispatch(
+        setErrorMessage(
+          "이미 사용 중인 파일이 있습니다. 기존의 파일을 삭제하고 진행해주세요.",
+        ),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Layout>
@@ -49,9 +74,23 @@ const AddVideoFileModal: React.FC = () => {
             </button>
           </div>
         )}
-        <DropzoneSection setVideoFile={setVideoFile} />
+        <DropzoneSection />
       </div>
       <ModalFooter />
+      {errorMessage && (
+        <PageToast
+          toastMsg={errorMessage}
+          isAccept={false}
+          onClose={() => dispatch(setErrorMessage(""))}
+        />
+      )}
+      {successMessage && (
+        <PageToast
+          toastMsg={successMessage}
+          isAccept={true}
+          onClose={() => dispatch(setSuccessMessage(""))}
+        />
+      )}
     </Layout>
   );
 };

--- a/src/components/classroomModal/createLecture/DropzoneSection.tsx
+++ b/src/components/classroomModal/createLecture/DropzoneSection.tsx
@@ -1,12 +1,7 @@
 import useVideoFileDrop from "@/hooks/lecture/useVideoFileDrop";
-interface DropzoneSectionProps {
-  setVideoFile: React.Dispatch<React.SetStateAction<File | null>>;
-}
 
-const DropzoneSection: React.FC<DropzoneSectionProps> = ({ setVideoFile }) => {
-  const { getRootProps, getInputProps, isDragActive } = useVideoFileDrop({
-    setVideoFile: setVideoFile,
-  });
+const DropzoneSection: React.FC = () => {
+  const { getRootProps, getInputProps, isDragActive } = useVideoFileDrop();
 
   return (
     <div
@@ -24,6 +19,7 @@ const DropzoneSection: React.FC<DropzoneSectionProps> = ({ setVideoFile }) => {
           ? "파일을 이곳에 드롭하세요"
           : "파일을 여기로 드래그 해주세요"}
       </p>
+
       <label
         htmlFor="videoFile"
         className="w-52 h-10 cursor-pointer font-bold text-base bg-grayscale-5 text-grayscale-50 rounded-[10px] flex flex-col justify-center items-center hover:text-white hover:bg-primary-80"

--- a/src/components/classroomModal/createLecture/DropzoneSection.tsx
+++ b/src/components/classroomModal/createLecture/DropzoneSection.tsx
@@ -1,42 +1,36 @@
 import useVideoFileDrop from "@/hooks/lecture/useVideoFileDrop";
-
 interface DropzoneSectionProps {
   setVideoFile: React.Dispatch<React.SetStateAction<File | null>>;
 }
 
 const DropzoneSection: React.FC<DropzoneSectionProps> = ({ setVideoFile }) => {
-  const { getRootProps, isDragActive, videoFileURL, handleDrop } =
-    useVideoFileDrop({
-      setVideoFile: setVideoFile,
-    });
+  const { getRootProps, getInputProps, isDragActive } = useVideoFileDrop({
+    setVideoFile: setVideoFile,
+  });
 
   return (
     <div
       {...getRootProps()}
-      className="h-72 border border-dashed border-grayscale-20 gap-[10px] rounded-[10px] flex flex-col justify-center items-center"
-      onClick={() => {}}
+      className="flex-1 gap-[10px] border-[10px] border-solid border-transparent rounded-[10px] flex flex-col justify-center items-center"
+      style={{
+        borderImageSource: "url('/images/dropzone-border.svg')",
+        borderImageSlice: "100",
+        borderImageRepeat: "repeat",
+        borderImageWidth: "10",
+      }}
     >
       <p className="text-grayscale-30 text-xl font-bold">
         {isDragActive
           ? "파일을 이곳에 드롭하세요"
           : "파일을 여기로 드래그 해주세요"}
       </p>
-
       <label
         htmlFor="videoFile"
         className="w-52 h-10 cursor-pointer font-bold text-base bg-grayscale-5 text-grayscale-50 rounded-[10px] flex flex-col justify-center items-center hover:text-white hover:bg-primary-80"
       >
         컴퓨터에서 파일 선택
       </label>
-      <input
-        type="file"
-        name="videoFile"
-        id="videoFile"
-        key={videoFileURL}
-        className="hidden"
-        accept="video/*"
-        onChange={e => handleDrop(e.target.files || [])}
-      />
+      <input {...getInputProps()} id="videoFile" />
     </div>
   );
 };

--- a/src/hooks/lecture/useVideoFileDrop.tsx
+++ b/src/hooks/lecture/useVideoFileDrop.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import { useDropzone } from "react-dropzone";
 
 interface useVideoFileDropProps {
@@ -6,51 +6,33 @@ interface useVideoFileDropProps {
 }
 
 const useVideoFileDrop = ({ setVideoFile }: useVideoFileDropProps) => {
-  const [videoFileURL, setVideoFileURL] = useState<string>("");
-
-  // 파일 업로드 핸들러
-  const handleDrop = useCallback(
-    (acceptedFiles: FileList | File[]) => {
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
       if (acceptedFiles.length !== 0) {
         const file: File = acceptedFiles[0];
         if (file.type.includes("video")) {
-          // 기존에 생성한 비디오 파일의 URL을 해제 -> 메모리 누수 방지
-          videoFileURL && URL.revokeObjectURL(videoFileURL);
-          setVideoFileURL(URL.createObjectURL(file));
           setVideoFile(file);
         }
       }
     },
-    [setVideoFile, videoFileURL],
+    [setVideoFile],
   );
-
-  // 업로드된 비디오파일 삭제 핸들러
   const handleRemoveVideoFile = () => {
     setVideoFile(null);
-    setVideoFileURL("");
   };
-
-  // Dropzone 컴포넌트 설정
-  const { getRootProps, isDragActive } = useDropzone({
-    // 드래그 앤 드롭과 파일 선택을 동시에 처리하는 핸들러 사용
-    onDrop: handleDrop,
-    accept: { "video/*": [] },
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    multiple: false,
+    accept: { "video/*": [".mp4", ".wav", ".avi"] },
+    noClick: true,
   });
-
-  // DropzoneSection 컴포넌트가 언마운트될 때 videoFileURL 해제
-  useEffect(() => {
-    return () => {
-      videoFileURL && URL.revokeObjectURL(videoFileURL);
-    };
-  }, [videoFileURL]);
 
   return {
     getRootProps,
+    getInputProps,
     isDragActive,
-    videoFileURL,
-    handleDrop,
+    onDrop,
     handleRemoveVideoFile,
   };
 };
-
 export default useVideoFileDrop;

--- a/src/hooks/lecture/useVideoFileDrop.tsx
+++ b/src/hooks/lecture/useVideoFileDrop.tsx
@@ -1,25 +1,56 @@
 import { useCallback } from "react";
-import { useDropzone } from "react-dropzone";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@/redux/store";
+import { FileRejection, useDropzone } from "react-dropzone";
+import {
+  setVideoFile,
+  setErrorMessage,
+  setSuccessMessage,
+  reset,
+} from "@/redux/slice/dropzoneFileSlice";
 
-interface useVideoFileDropProps {
-  setVideoFile: (file: File | null) => void;
-}
+const useVideoFileDrop = () => {
+  const dispatch = useDispatch();
+  const videoFile = useSelector(
+    (state: RootState) => state.dropzoneFile.videoFile,
+  );
 
-const useVideoFileDrop = ({ setVideoFile }: useVideoFileDropProps) => {
   const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
-      if (acceptedFiles.length !== 0) {
+    (acceptedFiles: File[], fileRejections: FileRejection[]) => {
+      if (videoFile) {
+        dispatch(
+          setErrorMessage(
+            "이미 사용 중인 파일이 있습니다. 기존의 파일을 삭제하고 진행해주세요.",
+          ),
+        );
+      } else if (acceptedFiles.length !== 0) {
         const file: File = acceptedFiles[0];
-        if (file.type.includes("video")) {
-          setVideoFile(file);
+        dispatch(setVideoFile(file));
+        dispatch(setSuccessMessage("파일이 업로드되었습니다!"));
+      } else if (fileRejections.length > 0) {
+        if (
+          fileRejections[0].errors[0].message ===
+          "File type must be video/*,.mp4,.wav,.avi"
+        ) {
+          dispatch(
+            setErrorMessage("파일 형식이 올바르지 않습니다. (mp4, wav, avi)"),
+          );
+        } else {
+          dispatch(
+            setErrorMessage(
+              `에러가 발생하였습니다. 다시 시도해주세요. (${fileRejections[0].errors[0].message})`,
+            ),
+          );
         }
       }
     },
-    [setVideoFile],
+    [dispatch, videoFile],
   );
+
   const handleRemoveVideoFile = () => {
-    setVideoFile(null);
+    dispatch(reset());
   };
+
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     multiple: false,
@@ -31,8 +62,8 @@ const useVideoFileDrop = ({ setVideoFile }: useVideoFileDropProps) => {
     getRootProps,
     getInputProps,
     isDragActive,
-    onDrop,
     handleRemoveVideoFile,
   };
 };
+
 export default useVideoFileDrop;

--- a/src/redux/slice/dropzoneFileSlice.tsx
+++ b/src/redux/slice/dropzoneFileSlice.tsx
@@ -1,0 +1,34 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+interface DropzoneFileState {
+  videoFile: File | null;
+  errorMessage: string;
+  successMessage: string;
+}
+
+const initialState: DropzoneFileState = {
+  videoFile: null,
+  errorMessage: "",
+  successMessage: "",
+};
+
+const dropzoneFileSlice = createSlice({
+  name: "dropzoneFile",
+  initialState,
+  reducers: {
+    setVideoFile: (state, action: PayloadAction<File | null>) => {
+      state.videoFile = action.payload;
+    },
+    setErrorMessage: (state, action: PayloadAction<string>) => {
+      state.errorMessage = action.payload;
+    },
+    setSuccessMessage: (state, action: PayloadAction<string>) => {
+      state.successMessage = action.payload;
+    },
+    reset: () => initialState,
+  },
+});
+
+export const { setVideoFile, setErrorMessage, setSuccessMessage, reset } =
+  dropzoneFileSlice.actions;
+export default dropzoneFileSlice.reducer;

--- a/src/redux/store.tsx
+++ b/src/redux/store.tsx
@@ -7,6 +7,7 @@ import { persistReducer, persistStore } from "redux-persist";
 import classroomModalReducer from "./slice/classroomModalSlice";
 import titleReducer from "./slice/lectureTitleSlice";
 import contentReducer from "./slice/linkContentSlice";
+import dropzoneFileReducer from "./slice/dropzoneFileSlice";
 
 const persistConfig = {
   key: "root",
@@ -20,6 +21,7 @@ export const store = configureStore({
     classroomModal: classroomModalReducer,
     title: titleReducer,
     content: contentReducer,
+    dropzoneFile: dropzoneFileReducer,
   },
   middleware: getDefaultMiddleware =>
     getDefaultMiddleware({ serializableCheck: false }),


### PR DESCRIPTION
## 개요 :mag:
* 강의 추가 모달창에서 dropzone 영역의 border가 간격이 넓기때문에 기존 border-dashed와 맞지 않음.
이에 피그마에서 이미지를 export한 뒤, border-image를 사용하여 스타일 구현
* 기존에 react-dropzone 라이브러리의 내장 함수를 제대로 활용하지 못하고 직접 구현했던 파일 업로드 함수 부분을 내장 함수로 대체하여 활용성을 높임
* 강의 추가/강의 수정 모달창에서 파일의 상태에 따라 toast 메세지창을 다르게 띄워야하는데, 이를 위해 우선 업로드할 파일과 에러메세지, 성공메세지의 상태를 관리할 수 있도록 리덕스 툴킷 slice 구현
* 이를 이용하여 파일이 비디오 포맷이 아닐경우, 이미 등록된 파일이 있을경우, 업로드 된 경우, 그외 에러가 발생했을 경우에 해당하는 toast 메세지창을 띄울 수 있도록 구현

## 작업사항 :memo:
close #110 
close #111 
close #112 
