### PR TITLE
Update: 댓글/답글 등록 및 삭제에 따른 랜더링 방식 수정

### DIFF
--- a/src/app/classroom/(components)/modal/comment/CommentForm.tsx
+++ b/src/app/classroom/(components)/modal/comment/CommentForm.tsx
@@ -1,22 +1,29 @@
 import React, { FC, useState, ChangeEvent, FormEvent } from "react";
 import useAuth from "@/hooks/user/useAuth";
 import useUsername from "@/hooks/user/useUserName";
+import { useDispatch } from "react-redux";
 import { useAddCommentMutation } from "@/hooks/lecture/useAddCommentMutation";
+import { setModalVisibility } from "@/redux/slice/classroomModalSlice";
 
 interface CommentFormProps {
   parentId?: string;
   lectureId: string;
+  isReply?: boolean;
 }
 
-const CommentForm: FC<CommentFormProps> = ({ parentId = "", lectureId }) => {
+const CommentForm: FC<CommentFormProps> = ({
+  parentId = "",
+  lectureId,
+  isReply,
+}) => {
   const [comment, setComment] = useState("");
   const user = useAuth();
   const username = useUsername(user?.uid ?? null);
   const mutation = useAddCommentMutation();
+  const dispatch = useDispatch();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(lectureId);
     if (user && lectureId) {
       mutation.mutate({
         content: comment,
@@ -25,6 +32,11 @@ const CommentForm: FC<CommentFormProps> = ({ parentId = "", lectureId }) => {
         userId: user.uid,
       });
       setComment("");
+      if (!isReply) {
+        dispatch(
+          setModalVisibility({ modalName: "commentModalOpen", visible: false }),
+        );
+      }
     }
   };
 

--- a/src/app/classroom/(components)/modal/comment/ReplySection.tsx
+++ b/src/app/classroom/(components)/modal/comment/ReplySection.tsx
@@ -35,7 +35,11 @@ const ReplySection: FC<ReplySectionProps> = ({ commentId, lectureId }) => {
               </li>
             ))}
         </ul>
-        <CommentForm parentId={commentId} lectureId={lectureId} />
+        <CommentForm
+          parentId={commentId}
+          lectureId={lectureId}
+          isReply={true}
+        />
       </Layout>
     )
   );

--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/CommentsSection.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/CommentsSection.tsx
@@ -31,7 +31,7 @@ const CommentsSection: FC<CommentsSectionProps> = ({
       {commentModalOpen && (
         <Layout>
           <h2 className="text-xl font-bold">댓글 달기</h2>
-          <CommentForm lectureId={lectureId} />
+          <CommentForm lectureId={lectureId} isReply={false} />
         </Layout>
       )}
     </ul>

--- a/src/hooks/lecture/useAddCommentMutation.tsx
+++ b/src/hooks/lecture/useAddCommentMutation.tsx
@@ -1,6 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { db } from "@/utils/firebase";
-import { addDoc, collection, doc, serverTimestamp, DocumentData } from "firebase/firestore";
+import {
+  addDoc,
+  collection,
+  doc,
+  serverTimestamp,
+  DocumentData,
+} from "firebase/firestore";
 
 const addCommentToDB = async (data: {
   content: string;
@@ -32,20 +38,25 @@ export const useAddCommentMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation(addCommentToDB, {
-    onMutate: async (newComment) => {
-      await queryClient.cancelQueries(['comments']);
-      const previousComments = queryClient.getQueryData<DocumentData[]>(['comments']);
-      queryClient.setQueryData(['comments'], (old: DocumentData[] | undefined) => {
-        return [...(old ?? []), newComment];
-      });
+    onMutate: async newComment => {
+      await queryClient.cancelQueries(["comments"]);
+      const previousComments = queryClient.getQueryData<DocumentData[]>([
+        "comments",
+      ]);
+      queryClient.setQueryData(
+        ["comments"],
+        (old: DocumentData[] | undefined) => {
+          return [...(old ?? []), newComment];
+        },
+      );
       return { previousComments };
-    },    
+    },
     onSettled: () => {
-      queryClient.invalidateQueries(['comments']);
+      queryClient.invalidateQueries(["comments"]);
     },
     onError: (_err, _newComment, context) => {
       if (context?.previousComments) {
-        queryClient.setQueryData(['comments'], context.previousComments);
+        queryClient.setQueryData(["comments"], context.previousComments);
       }
     },
   });

--- a/src/hooks/lecture/useGetComments.tsx
+++ b/src/hooks/lecture/useGetComments.tsx
@@ -9,6 +9,7 @@ import {
   getDocs,
   query,
   where,
+  orderBy,
 } from "firebase/firestore";
 
 /**
@@ -26,6 +27,7 @@ const fetchComments = async (
     const commentsQuery = query(
       collection(db, "lectureComments"),
       where("lectureId", "==", doc(db, "lectures", lectureId)),
+      orderBy("createdAt"),
     );
     const querySnapshot = await getDocs(commentsQuery);
 
@@ -46,6 +48,7 @@ const fetchComments = async (
     const commentsQuery = query(
       collection(db, "lectureComments"),
       where("parentId", "==", parentId),
+      orderBy("createdAt"),
     );
     const querySnapshot = await getDocs(commentsQuery);
 


### PR DESCRIPTION
## 개요 :mag:

이전에는 댓글과 답글을 등록, 삭제를 할 경우 페이지를 다시 요청해야 확인이 가능했는데,
지금은 다시 요청하지 않고도 자동으로 랜더링 될 수 있게 수정.
그리고 오래된 순으로 댓글, 답글이 정렬되도록 수정.

## 작업사항 :memo:

close #120 

## 테스트 방법(optional)
