### PR TITLE
Feat: 클래스룸에서 노트 생성 모달창의 내용 상태관리 및 toast ui editor 툴바 옵션 수정

### DIFF
--- a/src/app/classroom/(components)/modal/common/Layout.tsx
+++ b/src/app/classroom/(components)/modal/common/Layout.tsx
@@ -16,7 +16,7 @@ const Layout: React.FC<ModalProps> = ({ children }) => {
       onClick={() => dispatch(closeModal())}
     >
       <article
-        className="relative w-[770px] bg-white px-8 py-9 flex flex-col gap-5 rounded-[10px] border border-solid border-grayscale-10 drop-shadow-[0_0_8px_rgba(0,0,0,0.25)] box-border"
+        className="relative w-[770px] bg-white px-[35px] py-[40px] flex flex-col gap-5 rounded-[10px] border border-solid border-grayscale-10 drop-shadow-[0_0_8px_rgba(0,0,0,0.25)] box-border"
         onClick={e => e.stopPropagation()}
       >
         {children}
@@ -26,7 +26,7 @@ const Layout: React.FC<ModalProps> = ({ children }) => {
             alt="닫기 버튼"
             width={24}
             height={24}
-            className="absolute top-9 right-8"
+            className="absolute top-[40px] right-[35px]"
             onClick={() => dispatch(closeModal())}
           />
         </button>

--- a/src/app/classroom/(components)/modal/createLecture/AddNoteModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/AddNoteModal.tsx
@@ -1,9 +1,13 @@
+import dynamic from "next/dynamic";
 import Layout from "../common/Layout";
 import ModalFooter from "../common/ModalFooter";
 import LectureTitle from "../common/LectureTitle";
-import NoteSction from "./NoteSction";
 import ModalHeader from "../common/ModalHeader";
 import useClassroomModal from "@/hooks/lecture/useClassroomModal";
+
+const NoSsrEditor = dynamic(() => import("./NoteSection"), {
+  ssr: false,
+});
 
 const AddNoteModal: React.FC = () => {
   const { handleModalMove } = useClassroomModal();
@@ -20,7 +24,7 @@ const AddNoteModal: React.FC = () => {
         </button>
       </ModalHeader>
       <LectureTitle />
-      <NoteSction />
+      <NoSsrEditor />
       <ModalFooter />
     </Layout>
   );

--- a/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
@@ -1,14 +1,25 @@
+import { useRef } from "react";
 import { Editor } from "@toast-ui/react-editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
 
 const NoteSction: React.FC = () => {
+  const editorRef = useRef<Editor>(null);
+
+  const toolbarItems = [
+    ["heading", "bold", "italic", "strike"],
+    ["image", "link"],
+    ["ul", "ol", "task", "table"],
+  ];
+
   return (
     <Editor
+      ref={editorRef}
       placeholder="내용을 입력해주세요."
       hideModeSwitch={true}
       usageStatistics={false}
       initialEditType="markdown"
       useCommandShortcut={true}
+      toolbarItems={toolbarItems}
     />
   );
 };

--- a/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
@@ -1,9 +1,17 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { Editor } from "@toast-ui/react-editor";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@/redux/store";
+import { setLectureContent } from "@/redux/slice/lectureInfoSlice";
 import "@toast-ui/editor/dist/toastui-editor.css";
 
 const NoteSction: React.FC = () => {
   const editorRef = useRef<Editor>(null);
+  const dispatch = useDispatch();
+  const lectureContent = useSelector(
+    (state: RootState) => state.lectureInfo.lectureContent,
+  );
+  const [content, setContent] = useState<string | undefined>(lectureContent);
 
   const toolbarItems = [
     ["heading", "bold", "italic", "strike"],
@@ -11,15 +19,25 @@ const NoteSction: React.FC = () => {
     ["ul", "ol", "task", "table"],
   ];
 
+  const handleChangeContent = () => {
+    const newContent: string | undefined = editorRef.current
+      ?.getInstance()
+      .getMarkdown();
+    setContent(newContent);
+    dispatch(setLectureContent(newContent));
+  };
+
   return (
     <Editor
       ref={editorRef}
+      initialValue={content}
       placeholder="내용을 입력해주세요."
       hideModeSwitch={true}
       usageStatistics={false}
       initialEditType="markdown"
       useCommandShortcut={true}
       toolbarItems={toolbarItems}
+      onChange={handleChangeContent}
     />
   );
 };


### PR DESCRIPTION
## 개요 :mag:
* 클래스룸 모달창 Layout의 패딩값을 디자이너님이 지정해준 패딩값으로 수정
* 노트 생성 모달창의 toast ui editor 툴바에서 필요없는 옵션은 삭제하고, 사용자가 많이 사용해야하는 옵션 위주로 위치 변경
* toast ui editor는 SSR을 지원하지 않기 때문에 next.js에서 에러를 발생시킬 수 있음. 따라서 이 부분은 사용자 브라우저 단에서 렌더링 할 수 있도록 SSR 기능을 해제
* 사용자가 노트 생성 모달창에서 내용을 입력하는데 실수로 모달창을 닫거나, 이전 모달창으로 넘어갔다가 되돌아 왔을 경우 기존에 입력하던 내용이 유지될 수 있도록 redux-toolkit slice를 통해 상태 관리

## 작업사항 :memo:
close #123 
close #124 

