### PR TITLE
Style: 강의장에서는 layout 랜더링을 사용하지 않기에 style 수정

### DIFF
--- a/src/app/classroom/(components)/modal/common/ModalMain.tsx
+++ b/src/app/classroom/(components)/modal/common/ModalMain.tsx
@@ -9,7 +9,7 @@ interface ModalMainProps {
   children: ReactNode;
 }
 
-const ModalMain:React.FC<ModalMainProps> = ({children}) => {
+const ModalMain: React.FC<ModalMainProps> = ({ children }) => {
   const dispatch = useDispatch();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {

--- a/src/components/RequireAuth/RequireAuth.tsx
+++ b/src/components/RequireAuth/RequireAuth.tsx
@@ -2,6 +2,7 @@ import Navbar from "@/components/Header/Navbar";
 import Tab from "@/components/Header/Tab";
 import Footer from "@/components/Footer/Footer";
 import { useAppSelector } from "@/redux/store";
+import { useParams } from "next/navigation";
 
 export default function RequireAuth({
   children,
@@ -9,10 +10,11 @@ export default function RequireAuth({
   children: React.ReactNode;
 }) {
   const uid = useAppSelector(state => state.userId.uid);
+  const isLecturePage = useParams().lectureId?.length > 0;
 
   return (
     <>
-      {uid ? (
+      {uid && !isLecturePage ? (
         <>
           <Navbar />
           <Tab />

--- a/src/hooks/mutation/useAddComment.ts
+++ b/src/hooks/mutation/useAddComment.ts
@@ -16,11 +16,11 @@ const addCommentToDB = async (data: {
   userId: string;
 }) => {
   const { content, lectureId, parentId, userId } = data;
-
+  
   const userRef = doc(db, "users", userId);
   const lectureRef = doc(db, "lectures", lectureId);
-  const parentCommentRef = doc(db, "lectureComments", parentId);
-
+  const parentCommentRef = parentId ? doc(db, "lectureComments", parentId) : null;
+  
   const commentRef = doc(collection(db, "lectureComments"));
 
   const commentDoc = {
@@ -29,13 +29,12 @@ const addCommentToDB = async (data: {
     lectureId: lectureRef,
     parentId,
     replyCount: 0,
-    timestamp: "",
     updatedAt: serverTimestamp(),
     userId: userRef,
   };
 
   await runTransaction(db, async transaction => {
-    if (parentId) {
+    if (parentId && parentCommentRef) {
       const parentCommentSnapshot = await transaction.get(parentCommentRef);
       if (!parentCommentSnapshot.exists()) {
         throw Error("Parent comment does not exist!");

--- a/src/hooks/mutation/useAddComment.ts
+++ b/src/hooks/mutation/useAddComment.ts
@@ -16,11 +16,13 @@ const addCommentToDB = async (data: {
   userId: string;
 }) => {
   const { content, lectureId, parentId, userId } = data;
-  
+
   const userRef = doc(db, "users", userId);
   const lectureRef = doc(db, "lectures", lectureId);
-  const parentCommentRef = parentId ? doc(db, "lectureComments", parentId) : null;
-  
+  const parentCommentRef = parentId
+    ? doc(db, "lectureComments", parentId)
+    : null;
+
   const commentRef = doc(collection(db, "lectureComments"));
 
   const commentDoc = {


### PR DESCRIPTION
## 개요 :mag:

강의장에서는 기본적인 레이아웃(헤더, 푸터, 네비바)을 사용하지 않기 때문에 랜더링을 할 필요가 없음.
그래서 lectureId의 여부에 따라 랜더링이 되지 않도록 수정.

댓글이 달리지 않던 버그 수정

## 작업사항 :memo:

close #152 

## 테스트 방법(optional)

