### PR TITLE
Feat: 강의장 헤더 이미지 랜더링 기능 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,3 +2,9 @@
 const nextConfig = {};
 
 module.exports = nextConfig;
+
+module.exports = {
+  images: {
+    domains: ["firebasestorage.googleapis.com"],
+  },
+};

--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureHeader.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureHeader.tsx
@@ -1,9 +1,10 @@
 import { Timestamp } from "firebase/firestore";
-import { FC } from "react";
+import { FC, useState, useEffect } from "react";
 import { User } from "@/types/firebase.types";
 import timestampToDate from "@/utils/timestampToDate";
 import Image from "next/image";
 import Link from "next/link";
+import { getProfileImageURL } from "@/hooks/lecture/useProfileImageURL";
 
 interface LectureHeaderProps {
   title: string;
@@ -20,6 +21,14 @@ const LectureHeader: FC<LectureHeaderProps> = ({
 }) => {
   const startDay = timestampToDate(startDate);
   const endDay = timestampToDate(endDate);
+
+  const [profileImageURL, setProfileImageURL] = useState<string | null>(null);
+
+  useEffect(() => {
+    getProfileImageURL(user.profileImage)
+      .then(setProfileImageURL)
+      .catch(console.error);
+  }, [user.profileImage]);
 
   return (
     <header className="flex border-b border-gray-200 w-full h-40">
@@ -42,7 +51,19 @@ const LectureHeader: FC<LectureHeaderProps> = ({
           </span>
         </div>
         <div className="flex items-center mt-2">
-          <div className="w-7 h-7 bg-white border border-gray-300 rounded-full flex-shrink-0"></div>
+          {profileImageURL ? (
+            <div className="w-7 h-7 relative">
+              <Image
+                src={profileImageURL}
+                alt="사용자 이미지"
+                layout="fill"
+                objectFit="cover"
+                className="rounded-full"
+              />
+            </div>
+          ) : (
+            <div className="w-7 h-7 bg-white border border-gray-300 rounded-full flex-shrink-0"></div>
+          )}
           <div className="flex items-center ml-2">
             <span className=" text-sm font-semibold text-blue-500 ">
               {user.username}

--- a/src/hooks/lecture/useProfileImageURL.ts
+++ b/src/hooks/lecture/useProfileImageURL.ts
@@ -1,0 +1,9 @@
+import { getStorage, ref, getDownloadURL } from "firebase/storage";
+
+export async function getProfileImageURL(imagePath: string) {
+  const storage = getStorage();
+  const imageRef = ref(storage, imagePath);
+
+  const url = await getDownloadURL(imageRef);
+  return url;
+}


### PR DESCRIPTION
## 개요 :mag:

기존에는 강의장 헤더 부분에서 강의를 등록한 사람의 이미지가 흰원이었지만,
이제는 users 컬렉션에 profileImage에 저장된 image를 랜더링 할 수 있게 함.

이에 따라 next.config.js를 수정하고,
imageURL을 불러오는 함수를 추가함.

## 작업사항 :memo:

close #155 

## 테스트 방법(optional)


