### PR TITLE
Update: 강의장 이미지 랜더링 구현

### DIFF
--- a/src/app/classroom/(components)/modal/comment/Comment.tsx
+++ b/src/app/classroom/(components)/modal/comment/Comment.tsx
@@ -26,7 +26,7 @@ const Comment: React.FC<CommentProps> = ({
   onCommentClick,
 }) => {
   const { id, content, createdAt, parentId, replyCount } = comment;
-  const { username, role } = comment.user;
+  const { username, role, profileImage } = comment.user;
   const userId = comment.userId;
 
   const user = useAuth();
@@ -69,11 +69,13 @@ const Comment: React.FC<CommentProps> = ({
             content={content}
             username={username}
             role={role}
+            profileImage={profileImage}
             onEdit={handleEdit}
             onCancel={() => setIsEditMode(false)}
           />
         ) : (
           <ReadComment
+            profileImage={profileImage}
             displayedComment={displayedComment}
             username={username}
             role={role}

--- a/src/app/classroom/(components)/modal/comment/CommentForm.tsx
+++ b/src/app/classroom/(components)/modal/comment/CommentForm.tsx
@@ -1,9 +1,11 @@
 import React, { FC, useState, ChangeEvent, FormEvent } from "react";
 import useAuth from "@/hooks/user/useAuth";
 import useUsername from "@/hooks/user/useUserName";
+import useUserProfileImage from "@/hooks/user/useUserProfileImage";
 import { useDispatch } from "react-redux";
 import { useAddComment } from "@/hooks/mutation/useAddComment";
 import { setModalVisibility } from "@/redux/slice/classroomModalSlice";
+import UserImage from "./UserImage";
 
 interface CommentFormProps {
   parentId?: string;
@@ -18,6 +20,7 @@ const CommentForm: FC<CommentFormProps> = ({
   const [comment, setComment] = useState("");
   const user = useAuth();
   const username = useUsername(user?.uid ?? null);
+  const profileImage = useUserProfileImage(user?.uid ?? null);
   const mutation = useAddComment();
   const dispatch = useDispatch();
 
@@ -46,7 +49,7 @@ const CommentForm: FC<CommentFormProps> = ({
   return (
     <div className="flex w-full h-25 flex-col space-x-4 items-start rounded-lg border text-gray-500 ">
       <div className="flex ml-4 mt-2">
-        <div className="w-7 h-7 bg-white border border-gray-300 rounded-full"></div>
+        {profileImage && <UserImage profileImage={profileImage} />}
         <div className="ml-2 text-gray-500 mb-1 pt-[3px]">{username}</div>
       </div>
       <div className="flex w-full mb-2">

--- a/src/app/classroom/(components)/modal/comment/EditComment.tsx
+++ b/src/app/classroom/(components)/modal/comment/EditComment.tsx
@@ -6,6 +6,7 @@ interface EditCommentProps {
   content: string;
   username: string;
   role: string;
+  profileImage: string;
   onEdit: (newContent: string) => void;
   onCancel: () => void;
 }
@@ -13,6 +14,7 @@ const EditComment: React.FC<EditCommentProps> = ({
   content,
   username,
   role,
+  profileImage,
   onEdit,
   onCancel,
 }) => {
@@ -20,7 +22,7 @@ const EditComment: React.FC<EditCommentProps> = ({
 
   return (
     <div className="flex items-start space-x-4 w-full">
-      <UserImage />
+      <UserImage profileImage={profileImage} size="large" />
       <div className="flex flex-col w-full">
         <UserInfo username={username} role={role} />
         <div className="w-full flex justify-between items-start">

--- a/src/app/classroom/(components)/modal/comment/ReadComment.tsx
+++ b/src/app/classroom/(components)/modal/comment/ReadComment.tsx
@@ -6,15 +6,17 @@ interface ReadCommentProps {
   displayedComment: React.ReactNode[];
   username: string;
   role: string;
+  profileImage: string;
 }
 const ReadComment: React.FC<ReadCommentProps> = ({
   displayedComment,
   username,
   role,
+  profileImage,
 }) => {
   return (
     <div className="flex items-start space-x-4 w-full">
-      <UserImage />
+      <UserImage profileImage={profileImage} size="large" />
       <div className="flex flex-col w-full">
         <UserInfo username={username} role={role} />
         <CommentText displayedComment={displayedComment} />

--- a/src/app/classroom/(components)/modal/comment/UserImage.tsx
+++ b/src/app/classroom/(components)/modal/comment/UserImage.tsx
@@ -1,7 +1,38 @@
-import React from "react";
+import React, { FC, useState, useEffect } from "react";
+import Image from "next/image";
+import { getProfileImageURL } from "@/hooks/lecture/useProfileImageURL";
 
-const UserImage: React.FC = () => (
-  <div className="w-10 h-10 bg-white border border-gray-300 rounded-full flex-shrink-0"></div>
-);
+interface UserImageProps {
+  profileImage: string;
+  size?: "default" | "large";
+}
+
+const UserImage: FC<UserImageProps> = ({ profileImage, size = "default" }) => {
+  const [profileImageURL, setProfileImageURL] = useState<string | null>(null);
+
+  useEffect(() => {
+    getProfileImageURL(profileImage)
+      .then(setProfileImageURL)
+      .catch(console.error);
+  }, [profileImage]);
+
+  const wrapperClass = size === "default" ? "w-7 h-7" : "w-10 h-10";
+
+  return profileImageURL ? (
+    <div className={`${wrapperClass} relative rounded-full flex-shrink-0`}>
+      <Image
+        src={profileImageURL}
+        alt="사용자 이미지"
+        layout="fill"
+        objectFit="cover"
+        className="rounded-full"
+      />
+    </div>
+  ) : (
+    <div
+      className={`${wrapperClass} bg-white border border-gray-300 rounded-full flex-shrink-0`}
+    ></div>
+  );
+};
 
 export default UserImage;

--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureHeader.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureHeader.tsx
@@ -5,6 +5,7 @@ import timestampToDate from "@/utils/timestampToDate";
 import Image from "next/image";
 import Link from "next/link";
 import { getProfileImageURL } from "@/hooks/lecture/useProfileImageURL";
+import UserImage from "@/app/classroom/(components)/modal/comment/UserImage";
 
 interface LectureHeaderProps {
   title: string;
@@ -51,19 +52,7 @@ const LectureHeader: FC<LectureHeaderProps> = ({
           </span>
         </div>
         <div className="flex items-center mt-2">
-          {profileImageURL ? (
-            <div className="w-7 h-7 relative">
-              <Image
-                src={profileImageURL}
-                alt="사용자 이미지"
-                layout="fill"
-                objectFit="cover"
-                className="rounded-full"
-              />
-            </div>
-          ) : (
-            <div className="w-7 h-7 bg-white border border-gray-300 rounded-full flex-shrink-0"></div>
-          )}
+          {profileImageURL && <UserImage profileImage={profileImageURL} />}
           <div className="flex items-center ml-2">
             <span className=" text-sm font-semibold text-blue-500 ">
               {user.username}

--- a/src/hooks/user/useUserProfileImage.ts
+++ b/src/hooks/user/useUserProfileImage.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { getFirestore, doc, getDoc } from "firebase/firestore";
+
+const useUserProfileImage = (uid: string | null) => {
+  const [profileImage, setProfileImage] = useState<string | null>(null);
+  const db = getFirestore();
+
+  useEffect(() => {
+    if (uid) {
+      const fetchUserProfileImage = async () => {
+        const userDoc = doc(db, "users", uid);
+        const userSnap = await getDoc(userDoc);
+        if (userSnap.exists()) {
+            setProfileImage(userSnap.data().profileImage);
+        }
+      };
+
+      fetchUserProfileImage();
+    }
+  }, [db, uid]);
+
+  return profileImage;
+};
+
+export default useUserProfileImage;

--- a/src/hooks/user/useUserProfileImage.ts
+++ b/src/hooks/user/useUserProfileImage.ts
@@ -11,7 +11,7 @@ const useUserProfileImage = (uid: string | null) => {
         const userDoc = doc(db, "users", uid);
         const userSnap = await getDoc(userDoc);
         if (userSnap.exists()) {
-            setProfileImage(userSnap.data().profileImage);
+          setProfileImage(userSnap.data().profileImage);
         }
       };
 


### PR DESCRIPTION
## 개요 :mag:

강의장에서 이미지 랜더링 되는 부분 구현
강의장 헤더, 댓글, 답글, 수정 시 유저에 이미지가 보이는 부분,
유저가 갖고 있는 profileImage가 랜더링 되게 수정.

## 작업사항 :memo:

close #164 

## 테스트 방법(optional)

