### PR TITLE
Fix: 13버전에 맞지 않는 prop 사용으로 인한 경고 수정

### DIFF
--- a/src/app/classroom/(components)/modal/comment/UserImage.tsx
+++ b/src/app/classroom/(components)/modal/comment/UserImage.tsx
@@ -23,8 +23,8 @@ const UserImage: FC<UserImageProps> = ({ profileImage, size = "default" }) => {
       <Image
         src={profileImageURL}
         alt="사용자 이미지"
-        layout="fill"
-        objectFit="cover"
+        sizes="(max-width: 768px) 100vw"
+        fill={true}
         className="rounded-full"
       />
     </div>


### PR DESCRIPTION
## 개요 :mag:

강의장에서 UserImage를 렌더링 할 때, 콘솔 경고 메시지가 나옴.
원인은 Next 13에서 지원하지 않은 prop을 사용했었기 때문.
그래서 이를 fill prop으로 해결

## 작업사항 :memo:

close #176 

## 테스트 방법(optional)

