### PR TITLE
Feat: Content를 제외한 강의 정보(제목,수강기간,비공개여부 등등) 업로드 기능 구현

### DIFF
--- a/src/app/classroom/(components)/modal/common/LectureSetting.tsx
+++ b/src/app/classroom/(components)/modal/common/LectureSetting.tsx
@@ -1,32 +1,25 @@
+import { useDispatch } from "react-redux";
+import { Timestamp } from "firebase/firestore";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { ko } from "date-fns/locale";
 import {
   setStartDate,
   setEndDate,
-  setIsLecturePublic,
+  setIsLecturePrivate,
 } from "@/redux/slice/lectureInfoSlice";
-import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "@/redux/store";
-import { Timestamp } from "firebase/firestore";
+import useLectureInfo from "@/hooks/lecture/useLectureInfo";
 
 const LectureSetting: React.FC = () => {
-  const startDate = useSelector(
-    (state: RootState) => state.lectureInfo.startDate,
-  );
-  const endDate = useSelector((state: RootState) => state.lectureInfo.endDate);
-  const isLecturePublic = useSelector(
-    (state: RootState) => state.lectureInfo.isLecturePublic,
-  );
-
   const dispatch = useDispatch();
+  const { startDate, endDate, isLecturePrivate } = useLectureInfo();
 
   const handleToggle = () => {
-    dispatch(setIsLecturePublic(!isLecturePublic));
+    dispatch(setIsLecturePrivate(!isLecturePrivate));
   };
 
-  const handleChangeDate = (update: [Date, Date]) => {
-    const [startDate, endDate] = update;
+  const handleChangeDate = (ranges: [Date, Date]) => {
+    const [startDate, endDate] = ranges;
     dispatch(
       setStartDate(
         startDate ? new Timestamp(startDate.getTime() / 1000, 0) : null,
@@ -51,9 +44,10 @@ const LectureSetting: React.FC = () => {
           placeholderText="Pick a date"
           locale={ko}
           selected={startDate ? timestampToDate(startDate) : null}
-          onChange={handleChangeDate}
           startDate={startDate ? timestampToDate(startDate) : null}
           endDate={endDate ? timestampToDate(endDate) : null}
+          onChange={handleChangeDate}
+          minDate={new Date()}
           selectsRange
           className="bg-white border-2 border-gray-300 text-gray-900 text-sm rounded-lg block w-full p-2 cursor-pointer"
           dateFormat="yyyy.MM.dd"
@@ -69,7 +63,7 @@ const LectureSetting: React.FC = () => {
             id="toggle"
             name="toggle"
             className="hidden"
-            checked={isLecturePublic}
+            checked={isLecturePrivate}
             onChange={handleToggle}
           />
           <div
@@ -80,20 +74,20 @@ const LectureSetting: React.FC = () => {
               width: "100%",
               height: "100%",
               borderRadius: "26px",
-              backgroundColor: isLecturePublic ? "#e5eeff" : "#f2f2f2",
+              backgroundColor: isLecturePrivate ? "#f2f2f2" : "#e5eeff",
               transition: "all 0.4s ease-in-out",
             }}
-          ></div>
+          />
           <div
             className="absolute top-50%"
             style={{
               position: "absolute",
               top: "50%",
-              left: isLecturePublic ? "calc(100% - 21px)" : "5px",
+              left: isLecturePrivate ? "5px" : "calc(100% - 21px)",
               width: "16px",
               height: "16px",
               borderRadius: "13px",
-              backgroundColor: isLecturePublic ? "#337aff" : "#c5c5c5",
+              backgroundColor: isLecturePrivate ? "#c5c5c5" : "#337aff",
               boxShadow: "0px 1px 3px rgba(0, 0, 0, 0.3)",
               transition: "all 0.4s ease-in-out",
               transform: "translateY(-50%)",

--- a/src/app/classroom/(components)/modal/common/ModalFooter.tsx
+++ b/src/app/classroom/(components)/modal/common/ModalFooter.tsx
@@ -1,23 +1,6 @@
 import LectureSetting from "./LectureSetting";
-import { closeModal } from "@/redux/slice/classroomModalSlice";
-import { resetInput } from "@/redux/slice/lectureInfoSlice";
-import { useDispatch, useSelector } from "react-redux";
-import { RootState } from "@/redux/store";
 
 const ModalFooter: React.FC = () => {
-  const dispatch = useDispatch();
-  const startDate = useSelector(
-    (state: RootState) => state.lectureInfo.startDate,
-  );
-  const endDate = useSelector((state: RootState) => state.lectureInfo.endDate);
-
-  const lectureUpload = () => {
-    if (startDate && endDate) {
-    }
-
-    dispatch(closeModal());
-    dispatch(resetInput());
-  };
   return (
     <div className="flex justify-between mb-[-20px]">
       <LectureSetting />

--- a/src/app/classroom/(components)/modal/common/ModalMain.tsx
+++ b/src/app/classroom/(components)/modal/common/ModalMain.tsx
@@ -4,6 +4,8 @@ import LectureTitle from "./LectureTitle";
 import ModalFooter from "./ModalFooter";
 import { closeModal } from "@/redux/slice/classroomModalSlice";
 import { resetInput } from "@/redux/slice/lectureInfoSlice";
+import { useCreateLecture } from "@/hooks/mutation/useCreateLecture";
+import useLectureInfo from "@/hooks/lecture/useLectureInfo";
 
 interface ModalMainProps {
   children: ReactNode;
@@ -11,8 +13,32 @@ interface ModalMainProps {
 
 const ModalMain: React.FC<ModalMainProps> = ({ children }) => {
   const dispatch = useDispatch();
+  const mutation = useCreateLecture();
+  const {
+    user,
+    courseId,
+    lectureType,
+    lectureTitle,
+    lectureContent,
+    noteImages,
+    startDate,
+    endDate,
+    isLecturePrivate,
+  } = useLectureInfo();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (user && lectureType && startDate && endDate) {
+      mutation.mutate({
+        userId: user.uid,
+        courseId: courseId,
+        lectureType,
+        title: lectureTitle,
+        startDate,
+        endDate,
+        isPrivate: isLecturePrivate,
+      });
+    }
     dispatch(closeModal());
     dispatch(resetInput());
   };

--- a/src/app/classroom/(components)/sidebar/CourseList.tsx
+++ b/src/app/classroom/(components)/sidebar/CourseList.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useState } from "react";
-import { ICourseField, ILecture } from "@/hooks/queries/useGetCourseList";
-import Element from "./Element";
-import useSelectCourse from "@/hooks/classroom/useSelectCourse";
+import React from "react";
 import { useDispatch } from "react-redux";
+import Element from "./Element";
 import { setCourseId } from "@/redux/slice/lectureInfoSlice";
+import useSelectCourse from "@/hooks/classroom/useSelectCourse";
+import { ICourseField, ILecture } from "@/hooks/queries/useGetCourseList";
 
 interface IProps {
   courseList: ICourseField[];
-  setCurrentCourse: React.Dispatch<React.SetStateAction<any>>;
+  setCurrentCourse: React.Dispatch<React.SetStateAction<ICourseField>>;
 }
 
 const CourseList = ({ courseList, setCurrentCourse }: IProps) => {
@@ -23,32 +23,32 @@ const CourseList = ({ courseList, setCurrentCourse }: IProps) => {
     // courseId : "I7YsTuxOWvT1M2lakkAM"
     // lectureList : [{…}, {…}, {…}]
     // 2중 map, course순회 & course하위 lecture 순회
-    <React.Fragment>
-      {courseList.map((course: ICourseField, idx: number) => (
-        <>
-          <Element
-            key={course.courseData.title}
-            type="course"
-            title={course.courseData.title}
-            clickFn={() => handleCurrentCourse({ course, idx })!}
-            isSelected={selectedCourse[idx]}
-            uniqueId={course.courseId}
-            childCount={course.lectureList.length}
-          />
-          {/* 선택된 lecture만 보이도록 */}
-          {selectedCourse[idx] &&
-            course.lectureList.map((lecture: ILecture) => (
-              <Element
-                key={lecture.lectureId}
-                type="lecture"
-                title={lecture.title}
-                isSelected={selectedCourse[idx]}
-                uniqueId={lecture.lectureId}
-              />
-            ))}
-        </>
-      ))}
-    </React.Fragment>
+    courseList.map((course: ICourseField, idx: number) => (
+      <React.Fragment key={idx}>
+        <Element
+          type="course"
+          title={course.courseData.title}
+          clickFn={() => {
+            dispatch(setCourseId(course.courseId));
+            handleCurrentCourse({ course, idx })!;
+          }}
+          isSelected={selectedCourse[idx]}
+          uniqueId={course.courseId}
+          childCount={course.lectureList.length}
+        />
+        {/* 선택된 lecture만 보이도록 */}
+        {selectedCourse[idx] &&
+          course.lectureList.map((lecture: ILecture) => (
+            <Element
+              key={lecture.lectureId}
+              type="lecture"
+              title={lecture.title}
+              isSelected={selectedCourse[idx]}
+              uniqueId={lecture.lectureId}
+            />
+          ))}
+      </React.Fragment>
+    ))
   );
 };
 

--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -1,16 +1,23 @@
 "use client";
+import { useState, useEffect } from "react";
+import { useDispatch } from "react-redux";
 import Sidebar from "@/app/classroom/(components)/Sidebar";
 import ClassContent from "@/app/classroom/(components)/ClassContent";
-import useGetLectureList from "@/hooks/queries/useGetCourseList";
-import { useState, useEffect } from "react";
+import { setCourseId } from "@/redux/slice/lectureInfoSlice";
+import useGetLectureList, {
+  ICourseField,
+} from "@/hooks/queries/useGetCourseList";
 
 const Classroom = () => {
+  const dispatch = useDispatch();
+  const [currentCourse, setCurrentCourse] = useState<ICourseField>();
   const { data: courseList, isLoading: isLectureListFetch } =
     useGetLectureList();
-  const [currentCourse, setCurrentCourse] = useState<any>();
+
   useEffect(() => {
     if (!isLectureListFetch && courseList!.length !== 0) {
       setCurrentCourse(courseList![0]);
+      dispatch(setCourseId(courseList![0].courseId));
     }
   }, [isLectureListFetch]);
 

--- a/src/hooks/classroom/useSelectCourse.ts
+++ b/src/hooks/classroom/useSelectCourse.ts
@@ -1,11 +1,11 @@
-import React, { SetStateAction, useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { ICourseField } from "../queries/useGetCourseList";
 import { useSelector } from "react-redux";
 import { RootState } from "@/redux/store";
 
 interface IArg {
   courseList: ICourseField[];
-  setCurrentCourse: React.Dispatch<React.SetStateAction<any>>;
+  setCurrentCourse: React.Dispatch<React.SetStateAction<ICourseField>>;
 }
 
 // hook의 목적 : 선택된 Course관리

--- a/src/hooks/lecture/useLectureInfo.tsx
+++ b/src/hooks/lecture/useLectureInfo.tsx
@@ -7,34 +7,36 @@ const useLectureInfo = () => {
   const courseId: string = useSelector(
     (state: RootState) => state.lectureInfo.courseId,
   );
+  const lectureType: string = useSelector(
+    (state: RootState) => state.lectureInfo.lectureType,
+  );
   const lectureTitle: string = useSelector(
     (state: RootState) => state.lectureInfo.lectureTitle,
   );
   const lectureContent: string = useSelector(
     (state: RootState) => state.lectureInfo.lectureContent,
   );
-  const noteImages: File | null = useSelector(
+  const noteImages: string[] = useSelector(
     (state: RootState) => state.lectureInfo.noteImages,
   );
-  const lectureType: string = useSelector(
-    (state: RootState) => state.lectureInfo.lectureType,
+  const startDate = useSelector(
+    (state: RootState) => state.lectureInfo.startDate,
   );
-  const dateRange = useSelector(
-    (state: RootState) => state.lectureInfo.dateRange,
-  );
-  const isLecturePublic: boolean = useSelector(
-    (state: RootState) => state.lectureInfo.isLecturePublic,
+  const endDate = useSelector((state: RootState) => state.lectureInfo.endDate);
+  const isLecturePrivate: boolean = useSelector(
+    (state: RootState) => state.lectureInfo.isLecturePrivate,
   );
 
   return {
     user,
     courseId,
+    lectureType,
     lectureTitle,
     lectureContent,
     noteImages,
-    lectureType,
-    dateRange,
-    isLecturePublic,
+    startDate,
+    endDate,
+    isLecturePrivate,
   };
 };
 

--- a/src/hooks/mutation/useCreateLecture.ts
+++ b/src/hooks/mutation/useCreateLecture.ts
@@ -1,0 +1,71 @@
+import { LectureContent } from "@/types/firebase.types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { db } from "@/utils/firebase";
+import {
+  addDoc,
+  collection,
+  doc,
+  serverTimestamp,
+  Timestamp,
+} from "firebase/firestore";
+import { QUERY_KEY } from "@/constants/queryKey";
+
+interface LectureInfoType {
+  userId: string;
+  courseId: string;
+  title: string;
+  lectureType: string;
+  lectureContent?: LectureContent;
+  startDate: Timestamp;
+  endDate: Timestamp;
+  isPrivate: boolean;
+}
+
+const LectureInfo = async (data: LectureInfoType) => {
+  const {
+    title,
+    lectureType,
+    lectureContent,
+    startDate,
+    endDate,
+    isPrivate,
+    userId,
+    courseId,
+  } = data;
+
+  try {
+    const userRef = doc(db, "users", userId);
+    const courseRef = doc(db, "courses", courseId);
+    const lectureRef = collection(db, "lectures");
+
+    const lectureDoc = {
+      userId: userRef,
+      courseId: courseRef,
+      lectureType,
+      title,
+      // lectureContent,
+      startDate,
+      endDate,
+      isPrivate,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    };
+    await addDoc(lectureRef, lectureDoc);
+    return lectureRef;
+  } catch (error) {
+    console.error("강의 추가 중 오류가 발생했습니다:", error);
+  }
+};
+
+export const useCreateLecture = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(LectureInfo, {
+    onSettled: () => {
+      queryClient.invalidateQueries([QUERY_KEY.COURSE]);
+    },
+    onError: error => {
+      console.error("강의 추가에 실패했습니다: ", error);
+    },
+  });
+};

--- a/src/redux/slice/lectureInfoSlice.tsx
+++ b/src/redux/slice/lectureInfoSlice.tsx
@@ -51,7 +51,11 @@ const LectureInfoSlice = createSlice({
     setIsLecturePrivate: (state, action) => {
       state.isLecturePrivate = action.payload;
     },
-    resetInput: () => initialState,
+    resetInput: state => {
+      const { courseId } = state;
+      initialState;
+      state.courseId = courseId;
+    },
   },
 });
 

--- a/src/redux/slice/lectureInfoSlice.tsx
+++ b/src/redux/slice/lectureInfoSlice.tsx
@@ -6,11 +6,10 @@ interface LectureInfoState {
   lectureType: string;
   lectureTitle: string;
   lectureContent: string;
-  selectedModal: string | null;
+  noteImages: string[];
   startDate: Timestamp | null;
   endDate: Timestamp | null;
-  noteImages: File | null;
-  isLecturePublic: boolean;
+  isLecturePrivate: boolean;
 }
 
 const initialState: LectureInfoState = {
@@ -18,11 +17,10 @@ const initialState: LectureInfoState = {
   lectureType: "",
   lectureTitle: "",
   lectureContent: "",
-  selectedModal: null,
+  noteImages: [],
   startDate: null,
   endDate: null,
-  noteImages: null,
-  isLecturePublic: false,
+  isLecturePrivate: true,
 };
 
 const LectureInfoSlice = createSlice({
@@ -32,6 +30,9 @@ const LectureInfoSlice = createSlice({
     setCourseId: (state, action) => {
       state.courseId = action.payload;
     },
+    setLectureType: (state, action) => {
+      state.lectureType = action.payload;
+    },
     setLectureTitle: (state, action) => {
       state.lectureTitle = action.payload;
     },
@@ -39,20 +40,16 @@ const LectureInfoSlice = createSlice({
       state.lectureContent = action.payload;
     },
     setNoteImages: (state, action) => {
-      state.noteImages = action.payload;
-    },
-    setLectureType: (state, action) => {
-      state.lectureType = action.payload;
+      state.noteImages.push(action.payload);
     },
     setStartDate: (state, action) => {
       state.startDate = action.payload;
     },
-
     setEndDate: (state, action) => {
       state.endDate = action.payload;
     },
-    setIsLecturePublic: (state, action) => {
-      state.isLecturePublic = action.payload;
+    setIsLecturePrivate: (state, action) => {
+      state.isLecturePrivate = action.payload;
     },
     resetInput: () => initialState,
   },
@@ -60,12 +57,13 @@ const LectureInfoSlice = createSlice({
 
 export const {
   setCourseId,
+  setLectureType,
   setLectureTitle,
   setLectureContent,
-  setLectureType,
+  setNoteImages,
   setStartDate,
   setEndDate,
-  setIsLecturePublic,
+  setIsLecturePrivate,
   resetInput,
 } = LectureInfoSlice.actions;
 export default LectureInfoSlice.reducer;


### PR DESCRIPTION
## 개요 :mag:
* 업로드할 강의 정보 변수를 firebase type에 맞춰서 수정하였음
  * isLecturePublic -> isLecturePrivate
  * dateRange -> startDate와 endDate 2개로 나눔
* 강의 생성시 수강기간 관련 파일에서 필요없는 코드 삭제 및 코드 정리
* 강의 생성시 현재 위치한 섹션id를 기억할 수 있도록 상태 관리
* ❗ 섹션id를 상태관리 했음에도 모달창을 띄우면 값이 초기화되는 문제가 있었음
  * **원인** : 작성중이던 강의 정보를 상태관리하는 부분에서, 기존에 선택한 모달창이 아닌 다른 모달창을 선택하면 저장한 내용을 초기화하면서 섹션id까지 초기화되는 것이 문제였음.
  * **해결방법** : 초기화는 그대로하되, 섹션 id는 그대로 유지될 수 있도록 코드 변경
* 📢 **Content를 제외한 강의 정보(제목,수강기간,비공개여부,강사id,섹션id,업로드날짜 등) 업로드 기능 구현**
* `const [currentCourse, setCurrentCourse] = useState<>()`의 타입 변경
  * 기존 any -> 변경후 ICourseField
*  `CourseList` 컴포넌트에서 map사용시 key와 관련된 에러 해결

## 작업사항 :memo:
* closes #172 
* resolves #175 
