### PR TITLE
Feat: firebase cloud storage에 이미지 업로드

### DIFF
--- a/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
@@ -1,9 +1,12 @@
 import { useRef, useState } from "react";
-import { Editor } from "@toast-ui/react-editor";
 import { useDispatch, useSelector } from "react-redux";
+import { Editor } from "@toast-ui/react-editor";
 import { RootState } from "@/redux/store";
 import { setLectureContent } from "@/redux/slice/lectureInfoSlice";
+import useUploadNoteImage from "@/hooks/lecture/useUploadNoteImage";
 import "@toast-ui/editor/dist/toastui-editor.css";
+
+type HookCallback = (url: string, text?: string) => void;
 
 const NoteSction: React.FC = () => {
   const editorRef = useRef<Editor>(null);
@@ -12,6 +15,7 @@ const NoteSction: React.FC = () => {
     (state: RootState) => state.lectureInfo.lectureContent,
   );
   const [content, setContent] = useState<string | undefined>(lectureContent);
+  const { onUploadImage } = useUploadNoteImage();
 
   const toolbarItems = [
     ["heading", "bold", "italic", "strike"],
@@ -27,6 +31,16 @@ const NoteSction: React.FC = () => {
     dispatch(setLectureContent(newContent));
   };
 
+  const handleUploadImage = async (
+    imageFile: File | Blob,
+    callback: HookCallback,
+  ) => {
+    if (imageFile instanceof File) {
+      const imageURL: string | undefined = await onUploadImage(imageFile);
+      imageURL && callback(imageURL);
+    }
+  };
+
   return (
     <Editor
       ref={editorRef}
@@ -38,6 +52,9 @@ const NoteSction: React.FC = () => {
       useCommandShortcut={true}
       toolbarItems={toolbarItems}
       onChange={handleChangeContent}
+      hooks={{
+        addImageBlobHook: handleUploadImage,
+      }}
     />
   );
 };

--- a/src/hooks/lecture/useUploadNoteImage.ts
+++ b/src/hooks/lecture/useUploadNoteImage.ts
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { useDispatch } from "react-redux";
+import { storage } from "@/utils/firebase";
+import { getDownloadURL, ref, uploadBytes } from "firebase/storage";
+import { setNoteImages } from "@/redux/slice/lectureInfoSlice";
+
+const useUploadNoteImage = () => {
+  const [isUploading, setUploading] = useState<boolean>(false);
+  const dispatch = useDispatch();
+
+  const onUploadImage = async (imageFile: File) => {
+    const storageRef = ref(storage);
+    const noteImageRef = ref(
+      storageRef,
+      `lectures/noteImages/${imageFile.name}`,
+    );
+
+    try {
+      setUploading(true);
+      const snapshot = await uploadBytes(noteImageRef, imageFile);
+      const url = await getDownloadURL(snapshot.ref);
+      dispatch(setNoteImages(url));
+      return url;
+    } catch (error) {
+      console.error("Error uploading image:", error);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return { onUploadImage };
+};
+
+export default useUploadNoteImage;

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -1,6 +1,7 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 import { getAuth } from "firebase/auth";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
@@ -19,5 +20,6 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
+const storage = getStorage(app);
 const auth = getAuth(app);
-export { db, auth };
+export { db, auth, storage };


### PR DESCRIPTION
## 개요 :mag:
* firebase cloud storage 사용을 위해 `ultils/firebase.ts`에 설정 추가함
* firebase storage에 이미지 업로드 기능 구현
* toast ui editor에서는 이미지 업로드시 base64로 인코딩한 뒤 보여주는데, 코드가 길어지고 로딩 속도가 오래걸린다는 단점이 있음. 이 부분을 담당하는 `addImageBlobHook` 내장함수에서 base64로 인코딩하지 않고, firebase storage에 업로드된 이미지의 URL를 받아와서 저장해주는 방식으로 구현

## 작업사항 :memo:
* close #186 
