### PR TITLE
Update: 태그를 강조하는 함수에 타임스탬프도 강조하는 기능 추가

### DIFF
--- a/src/utils/highlightTags.tsx
+++ b/src/utils/highlightTags.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 function highlightTags(comment: string) {
-  const tagPattern = /(@\S+)/g;
+  const tagPattern = /(@\S+)|(\b\d{2}:\d{2}\b)/g;
   const words = comment.split(" ");
 
   const highlightedComment = words


### PR DESCRIPTION
## 개요 :mag:

태그와 함께 댓글을 남길 경우 태그를 강조하는 함수가 있었는데,
이제는 타임스탬프(00:00)의 댓글을 남길 경우에도 강조 할 수 있음.

## 작업사항 :memo:

close #209 

## 테스트 방법(optional)


