### PR TITLE
Feat: 노트만들기 모달창에서 Content(노트 내용) 업로드 기능 구현

### DIFF
--- a/src/app/classroom/(components)/modal/common/ModalMain.tsx
+++ b/src/app/classroom/(components)/modal/common/ModalMain.tsx
@@ -19,7 +19,7 @@ const ModalMain: React.FC<ModalMainProps> = ({ children }) => {
     courseId,
     lectureType,
     lectureTitle,
-    lectureContent,
+    textContent,
     noteImages,
     startDate,
     endDate,

--- a/src/app/classroom/(components)/modal/common/ModalMain.tsx
+++ b/src/app/classroom/(components)/modal/common/ModalMain.tsx
@@ -26,6 +26,11 @@ const ModalMain: React.FC<ModalMainProps> = ({ children }) => {
     isLecturePrivate,
   } = useLectureInfo();
 
+  const lectureContent = {
+    images: noteImages,
+    textContent,
+  };
+
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (user && lectureType && startDate && endDate) {
@@ -34,6 +39,7 @@ const ModalMain: React.FC<ModalMainProps> = ({ children }) => {
         courseId: courseId,
         lectureType,
         title: lectureTitle,
+        lectureContent,
         startDate,
         endDate,
         isPrivate: isLecturePrivate,

--- a/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
@@ -37,6 +37,7 @@ const NoteSction: React.FC = () => {
   ) => {
     if (imageFile instanceof File) {
       const imageURL: string | undefined = await onUploadImage(imageFile);
+      dispatch(setNoteImages(imageURL));
       imageURL && callback(imageURL);
     }
   };

--- a/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Editor } from "@toast-ui/react-editor";
 import { RootState } from "@/redux/store";
-import { setLectureContent } from "@/redux/slice/lectureInfoSlice";
+import { setNoteImages, setTextContent } from "@/redux/slice/lectureInfoSlice";
 import useUploadNoteImage from "@/hooks/lecture/useUploadNoteImage";
 import "@toast-ui/editor/dist/toastui-editor.css";
 
@@ -11,10 +11,10 @@ type HookCallback = (url: string, text?: string) => void;
 const NoteSction: React.FC = () => {
   const editorRef = useRef<Editor>(null);
   const dispatch = useDispatch();
-  const lectureContent = useSelector(
-    (state: RootState) => state.lectureInfo.lectureContent,
+  const textContent = useSelector(
+    (state: RootState) => state.lectureInfo.textContent,
   );
-  const [content, setContent] = useState<string | undefined>(lectureContent);
+  const [content, setContent] = useState<string | undefined>(textContent);
   const { onUploadImage } = useUploadNoteImage();
 
   const toolbarItems = [
@@ -28,7 +28,7 @@ const NoteSction: React.FC = () => {
       ?.getInstance()
       .getMarkdown();
     setContent(newContent);
-    dispatch(setLectureContent(newContent));
+    dispatch(setTextContent(newContent));
   };
 
   const handleUploadImage = async (

--- a/src/hooks/lecture/useLectureInfo.tsx
+++ b/src/hooks/lecture/useLectureInfo.tsx
@@ -13,8 +13,8 @@ const useLectureInfo = () => {
   const lectureTitle: string = useSelector(
     (state: RootState) => state.lectureInfo.lectureTitle,
   );
-  const lectureContent: string = useSelector(
-    (state: RootState) => state.lectureInfo.lectureContent,
+  const textContent: string = useSelector(
+    (state: RootState) => state.lectureInfo.textContent,
   );
   const noteImages: string[] = useSelector(
     (state: RootState) => state.lectureInfo.noteImages,
@@ -32,7 +32,7 @@ const useLectureInfo = () => {
     courseId,
     lectureType,
     lectureTitle,
-    lectureContent,
+    textContent,
     noteImages,
     startDate,
     endDate,

--- a/src/hooks/mutation/useCreateLecture.ts
+++ b/src/hooks/mutation/useCreateLecture.ts
@@ -43,7 +43,7 @@ const LectureInfo = async (data: LectureInfoType) => {
       courseId: courseRef,
       lectureType,
       title,
-      // lectureContent,
+      lectureContent,
       startDate,
       endDate,
       isPrivate,

--- a/src/redux/slice/lectureInfoSlice.tsx
+++ b/src/redux/slice/lectureInfoSlice.tsx
@@ -53,7 +53,7 @@ const LectureInfoSlice = createSlice({
     },
     resetInput: state => {
       const { courseId } = state;
-      initialState;
+      Object.assign(state, initialState);
       state.courseId = courseId;
     },
   },

--- a/src/redux/slice/lectureInfoSlice.tsx
+++ b/src/redux/slice/lectureInfoSlice.tsx
@@ -5,7 +5,7 @@ interface LectureInfoState {
   courseId: string;
   lectureType: string;
   lectureTitle: string;
-  lectureContent: string;
+  textContent: string;
   noteImages: string[];
   startDate: Timestamp | null;
   endDate: Timestamp | null;
@@ -16,7 +16,7 @@ const initialState: LectureInfoState = {
   courseId: "",
   lectureType: "",
   lectureTitle: "",
-  lectureContent: "",
+  textContent: "",
   noteImages: [],
   startDate: null,
   endDate: null,
@@ -36,8 +36,8 @@ const LectureInfoSlice = createSlice({
     setLectureTitle: (state, action) => {
       state.lectureTitle = action.payload;
     },
-    setLectureContent: (state, action) => {
-      state.lectureContent = action.payload;
+    setTextContent: (state, action) => {
+      state.textContent = action.payload;
     },
     setNoteImages: (state, action) => {
       state.noteImages.push(action.payload);
@@ -63,7 +63,7 @@ export const {
   setCourseId,
   setLectureType,
   setLectureTitle,
-  setLectureContent,
+  setTextContent,
   setNoteImages,
   setStartDate,
   setEndDate,

--- a/src/types/firebase.types.ts
+++ b/src/types/firebase.types.ts
@@ -119,11 +119,11 @@ export interface LectureComment {
 }
 
 export interface LectureContent {
-  images: string[];
-  textContent: string;
-  externalLink: string;
-  videoUrl: string;
-  videoLength: number;
+  images?: string[];
+  textContent?: string;
+  externalLink?: string;
+  videoUrl?: string;
+  videoLength?: number;
 }
 
 export interface AttachmentFile {


### PR DESCRIPTION
## 개요 :mag:
* 강의 내용 업로드시 노트/비디오/링크 중 하나를 선택해서 올리는 것이기 때문에 firebase.types의 LectrueContent 모든 요소를 전달할 수 없음. 이에 따라 선택적 프로퍼티(옵셔널 체이닝)를 적용함으로써 필요한 값만 받을 수 있도록 변경
* 노트 만들기 모달창에서 노트내용 저장하는 변수명 변경
  * 기존 `lectureContent` -> `textContent`
* ❗노트만들기 모달창에서 노트 작성 중 이미지를 삽입할 경우 : 업로드한 이미지들의 url을 받아와서 string[]타입으로 상태관리하고, 모달창의 업로드 버튼 클릭시 이러한 이미지들 정보와 노트 내용(text)을 firestore에 전송할 수 있는 업로드 기능 구현
*` lectureInfoSlice`에서 `cousrseId`를 제외한 정보를 초기화하는 코드에 제대로 작동하지 않아서 수정하였음.


## 작업사항 :memo:
* resolve #175 
