### PR TITLE
Feat: LeftNav에 Dnd 기반 과제순서변경 기능 및 데이터 업데이트 함수 추가

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/src/app/assignment/(components)/AssignmentLeftNavContent.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContent.tsx
@@ -1,29 +1,71 @@
 "use client";
 
 import React from "react";
-import Link from "next/link";
-import { Assignment } from "@/types/firebase.types";
 import { useGetAssignment } from "@hooks/queries/useGetAssignment";
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
+import AssignmentLeftNavBlock from './AssignmentLeftNavContentCard'
+import {useState, useEffect, useCallback, useRef} from 'react'
+import {AssignmentExtracted} from './AssignmentLeftNavContentCard'
 
-interface AssignmentNumberAdded extends Assignment {
-  assignmentNumber: number;
-}
+type AssignmentExtractedOmitted = Omit<AssignmentExtracted, 'movecard'>
 
 const AssignmentLeftNavContent = () => {
-  const assignmentData = useGetAssignment("");
+  const assignQueries = useGetAssignment("");
+  const [htmlContent, setHtmlcontent] = useState<AssignmentExtractedOmitted[]>()
+  const isLoading = assignQueries.isLoading
+  console.log("[COMP]AssignmentLeftNavContent 실행!", htmlContent);
+  console.log("isLoading:", isLoading);
 
-  if (assignmentData.isLoading === false) {
-    const assignment = assignmentData.data;
-    const htmlContent = assignment?.map((assign: AssignmentNumberAdded) => (
-      <li key={assign.assignmentNumber} className="list-none w-full p-[10px]">
-        <Link href={"/assignment/" + assign.assignmentNumber}>
-          {assign.title}
-        </Link>
-      </li>
-    ));
+  //최초 로드시 데이터 fetch(데이터 POST 후의 로드는 고려하지 않음)
+  const FetchAssignmentData = useCallback(()=>{
+    console.log("[COMP_FUNC]FetchAssignmentData 실행!", isLoading);
+    let htmlcontent=[]
 
-    return htmlContent;
-  }
-};
+    if (isLoading === false) {
+      console.log('데이터 로드!');
+      const assignFetched = assignQueries.data;
+      let index = assignFetched?.length; 
+      //order 순서대로 데이터 불러오기 및 추출(이후에는 moveCard로 순서보존)
+
+      for (let i=1; i<index; i++){
+        let assignCopied = assignFetched?.find(assignAll=>assignAll.order===i);
+
+        if (assignCopied!==undefined){ //order 있을경우에만 push
+          let assignExtracted = {id:assignCopied.id, index: htmlcontent.length, order:assignCopied.order, title:assignCopied.title}
+          htmlcontent.push(assignExtracted);
+        }
+      }
+      console.log('데이터 로드 완료!', htmlcontent);
+      setHtmlcontent(htmlcontent);
+    }
+  },[isLoading])
+
+  useEffect(()=>{
+    FetchAssignmentData()
+  },[FetchAssignmentData]);
+
+  //index 서로 바꾸고 컴포넌트 리로드
+  const moveCard = (dragIndex, hoverIndex) => {
+    console.log("[COMP_FUNC]moveCard 실행!");
+    let htmlcontent = [...htmlContent]
+
+    setHtmlcontent((prev)=>{
+      htmlcontent.splice(dragIndex,1,htmlcontent[hoverIndex])
+      htmlcontent.splice(hoverIndex,1,prev[dragIndex])
+      return (htmlcontent)
+    })
+  };
+
+    return (
+      <DndProvider backend={HTML5Backend}>
+        { isLoading?<span>`none`</span>:(htmlContent?.map((assignExtracted)=>{
+          console.log('데이터 매핑 시작!', assignExtracted)
+          return(
+              <AssignmentLeftNavBlock key={Math.random()} index={assignExtracted.index} order={assignExtracted.order} id={assignExtracted.id} title={assignExtracted.title} movecard={moveCard}/>)}))
+        }
+      </DndProvider>
+      );
+  };
 
 export default AssignmentLeftNavContent;

--- a/src/app/assignment/(components)/AssignmentLeftNavContent.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContent.tsx
@@ -7,13 +7,19 @@ import { HTML5Backend } from 'react-dnd-html5-backend'
 import AssignmentLeftNavBlock from './AssignmentLeftNavContentCard'
 import {useState, useEffect, useCallback, useRef} from 'react'
 import {AssignmentExtracted} from './AssignmentLeftNavContentCard'
+import {writeBatch, doc} from 'firebase/firestore'
+import { db } from "@utils/firebase";
 
 type AssignmentExtractedOmitted = Omit<AssignmentExtracted, 'movecard'>
+type AssignmentExtractedPicked = Pick<AssignmentExtracted, 'id'|'order'> //id가 assignmentId인지 확인필요
 
 const AssignmentLeftNavContent = () => {
   const assignQueries = useGetAssignment("");
   const [htmlContent, setHtmlcontent] = useState<AssignmentExtractedOmitted[]>()
   const isLoading = assignQueries.isLoading
+  const initialOrder = useRef<AssignmentExtractedPicked[]>();
+  const currentOrder = useRef<AssignmentExtractedPicked[]>();
+
   console.log("[COMP]AssignmentLeftNavContent 실행!", htmlContent);
   console.log("isLoading:", isLoading);
 
@@ -21,6 +27,7 @@ const AssignmentLeftNavContent = () => {
   const FetchAssignmentData = useCallback(()=>{
     console.log("[COMP_FUNC]FetchAssignmentData 실행!", isLoading);
     let htmlcontent=[]
+    let initialorder=[]
 
     if (isLoading === false) {
       console.log('데이터 로드!');
@@ -33,11 +40,14 @@ const AssignmentLeftNavContent = () => {
 
         if (assignCopied!==undefined){ //order 있을경우에만 push
           let assignExtracted = {id:assignCopied.id, index: htmlcontent.length, order:assignCopied.order, title:assignCopied.title}
+          let orderExtracted = {id:assignCopied.id, order:assignCopied.order}
           htmlcontent.push(assignExtracted);
+          initialorder.push(orderExtracted);
         }
       }
       console.log('데이터 로드 완료!', htmlcontent);
       setHtmlcontent(htmlcontent);
+      initialOrder.current=initialorder;
     }
   },[isLoading])
 
@@ -56,6 +66,23 @@ const AssignmentLeftNavContent = () => {
       return (htmlcontent)
     })
   };
+
+  const UpdateAssignmentOrder = async() => {
+    console.log('[COMP_FUNC]UpdateAssignmentOrder 실행!');
+    
+    //? transaction(batch)으로 일괄처리하는게 좋을 듯합니다.
+    const batch = writeBatch(db);
+
+    for (let i=0; i<htmlContent?.length; i++){
+      let targetId = htmlContent[i].id //현재 htmlcontent에서 id 추출
+      let targetDat = initialOrder.filter((data)=> data.id === targetId) //해당 id로 initialOrder의 order 값 추출
+      let newOrder = targetDat.order 
+      const assignRef = doc(db, 'assignment', targetId);
+      batch.update(assignRef,{"order" : newOrder}); //updateDoc
+    }
+
+    await batch.commit();//commit
+    }
 
     return (
       <DndProvider backend={HTML5Backend}>

--- a/src/app/assignment/(components)/AssignmentLeftNavContentCard.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContentCard.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { Assignment } from "@/types/firebase.types";
+import {useDrag, useDrop} from 'react-dnd'
+import {useRef} from 'react'
+
+export interface AssignmentExtracted extends Pick<Assignment, "id" | "order" | "title" > {
+  movecard:(dragIndex:Number, hoverIndex:Number)=> void;
+  index:number;
+}
+
+const AssignmentLeftNavBlock = (props:AssignmentExtracted) => {
+  console.log("[COMP]AssignmentLeftNavBlock 실행!");
+
+  const ref = useRef<HTMLDivElement>(null)
+  const {id, order, title, movecard, index} = props;
+  const [{isDragging}, drag] = useDrag(
+    ()=> ({
+      type: "card",
+      item: ()=>{
+          return {index}},
+      collect: (monitor:any) => ({
+        isDragging: monitor.isDragging()
+      })
+    })
+  )
+
+  const [, drop] = useDrop(
+    () => ({
+      accept : "card",
+      hover(item: AssignmentExtracted){
+        if (!ref.current) {
+          return
+        }
+        const dragIndex = item.index
+        const hoverIndex = index
+        
+      // Don't replace items with themselves
+      if (dragIndex === hoverIndex) {
+        return
+      }
+        movecard(dragIndex, hoverIndex)
+        console.log(dragIndex, hoverIndex)
+
+        item.index = hoverIndex
+      },
+    })
+  )
+  const opacity = isDragging ? 0 : 100
+  drag(drop(ref))
+  
+  return(
+      <div ref={ref} key={id} className={`list-none w-full p-[10px] order-${index} opacity-${opacity}`}>
+        <Link href={"/assignment/" + order}>
+          {title}
+        </Link>
+      </div>
+    )
+};
+
+export default AssignmentLeftNavBlock;

--- a/src/app/assignment/(components)/AssignmentListContent.tsx
+++ b/src/app/assignment/(components)/AssignmentListContent.tsx
@@ -26,7 +26,7 @@ const AssignmentListContent = () => {
     //map이 assignmentInfo의 property로 인식되어 경고문구가 뜸
     htmlContent = assignmentInfo?.map((assign: AssignmentNumberAdded) => (
       <div
-        key={Math.random()}
+        key={Math.random()} //? id 값으로 좋은 것?
         className="w-[775px] px-[24px] py-[16px] flex-shrink-0 rounded-[10px] mb-[20px] border border-grayscale-5 bg-grayscale-0 flex justify-between items-center"
       >
         <div className="flex w-[244px] flex-col items-start gap-[10px]">

--- a/src/app/assignment/(components)/AssignmentListContent.tsx
+++ b/src/app/assignment/(components)/AssignmentListContent.tsx
@@ -26,7 +26,7 @@ const AssignmentListContent = () => {
     //map이 assignmentInfo의 property로 인식되어 경고문구가 뜸
     htmlContent = assignmentInfo?.map((assign: AssignmentNumberAdded) => (
       <div
-        key={assign.assignmentNumber}
+        key={Math.random()}
         className="w-[775px] px-[24px] py-[16px] flex-shrink-0 rounded-[10px] mb-[20px] border border-grayscale-5 bg-grayscale-0 flex justify-between items-center"
       >
         <div className="flex w-[244px] flex-col items-start gap-[10px]">

--- a/src/hooks/mutation/useUpdateAssignment.ts
+++ b/src/hooks/mutation/useUpdateAssignment.ts
@@ -7,7 +7,7 @@ import { Assignment } from "@/types/firebase.types";
 const updateAssignment = async (assignmentValue: Assignment) => {
   try {
     const updateAssignment = await updateDoc(
-      doc(db, "assignments", "assignmentValue.id"),
+      doc(db, "assignments", "assignmentValue.id"),//? 인자연결 안됨
       { ...assignmentValue },
     );
     return updateAssignment;
@@ -16,7 +16,7 @@ const updateAssignment = async (assignmentValue: Assignment) => {
     throw err;
   }
 };
-
+//? updateAssignment에 인자 전달이 안됨
 const useUpdateAssignment = () => {
   const queryClient = useQueryClient();
   const { mutate, isLoading, error } = useMutation(updateAssignment, {

--- a/src/hooks/queries/useGetSubmittedAssignment.ts
+++ b/src/hooks/queries/useGetSubmittedAssignment.ts
@@ -15,10 +15,10 @@ import { SubmittedAssignment, Attachment } from "@/types/firebase.types";
 const getSubmittedAssignments = async (assignmentId: string): Promise<any> => {
   const assignmentRef = doc(db, "assignments", assignmentId);
   const assignmentDoc = await getDoc(assignmentRef);
-  const loginUserRef = doc(db, "users", "유저아이디 넣기");
+  const loginUserRef = doc(db, "users", "유저아이디 넣기"); //? 유저아이디 안들어감
   const loginUserDoc = await getDoc(loginUserRef);
 
-  if (!"수강생일때 조건문 넣기") {
+  if (!"수강생일때 조건문 넣기") { //? 조건문 안들어감
     const submittedAssignmentsQuery = query(
       collection(db, "submittedAssignments"),
       where("assignmentId", "==", assignmentDoc.ref),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,6 @@
       "@utils/*": ["./src/utils/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "src/app/assignment/(components)/AssignmentLeftNavContentCardtsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 개요 :mag:

1. **[과제순서변경 기능추가]** 왼쪽 네비게이션에 목록을 드래그시 과제 순서가 변경할 수 있도록 구현하였습니다.
2. **[데이터 업데이터 함수추가]** 과제 순서변경 후 `order`을 firestore에 update할 수 있는 함수를 구현하였습니다(연결 x).

## 작업사항 :memo:
1.  과제순서변경 기능추가
- 여러번 드래그시 순서변경 기능이 불안정해질 수 있습니다(추후 리팩토링 예정)
- on/off 기능은 아직 구현되지 않았습니다.
- firestore에 update하는 기능은 아직 구현되지 않았습니다.

2. 데이터 업데이트 함수추가
- 순서변경 버튼과 기능을 연결하지 않았습니다.
- 제가 hook으로 기능을 구현해놓긴 했으나, test는 진행하지 않았습니다.
- `useUpdateAssignment` 에서 @Hun5LEE 재훈님에게 수정요청할 부분이 있습니다. 내일 구두로 설명드릴게요!
- @Hun5LEE 과제순서 변경 시 `batch`를 활용하는 것을 고려해보려 합니다.
- `id` 값으로 부여할만한 값이 무엇이 있을지 고민됩니다..

`#37`  : Dnd 기능연결
`#37`  : 네비게이션 버튼 클릭시 순서 저장

## 테스트 방법(optional)
왼쪽 네비게이션에서 목록 클릭 후 위/아래로 드래그해보시면 됩니다.
