### PR TITLE
Feat: 수정된 과제 데이터 저장

### DIFF
--- a/src/app/assignment/(components)/AssignmentCreate.tsx
+++ b/src/app/assignment/(components)/AssignmentCreate.tsx
@@ -115,9 +115,9 @@ const AssignmentCreate: React.FC<AssignmentCreateProps> = ({
           className="w-[245px] h-[40px] bg-white border rounded-xl text-grayscale-40 mb-[17px] pl-2"
         >
           <option className="text-grayscale-40">난이도를 선택해주세요</option>
-          <option value="상">상</option>
+          <option value="초">초</option>
           <option value="중">중</option>
-          <option value="하">하</option>
+          <option value="고">고</option>
         </select>
       </div>
 

--- a/src/app/assignment/(components)/AssignmentUpdate.tsx
+++ b/src/app/assignment/(components)/AssignmentUpdate.tsx
@@ -5,6 +5,7 @@ import { Assignment } from "@/types/firebase.types";
 import PageToast from "@/components/PageToast";
 import { useUpdateAssignment } from "@/hooks/mutation/useUpdateAssignment";
 import { useGetAssignment } from "@/hooks/queries/useGetAssignment";
+import timestampToDate from "@/utils/timestampToDate";
 
 interface AssignmentUpdateProps {
   isOpen: boolean;
@@ -29,10 +30,11 @@ const AssignmentUpdate: React.FC<AssignmentUpdateProps> = ({
     reset,
   } = useForm<Assignment>();
 
-  const updateAssignmentMutation = useUpdateAssignment();
+  const updateAssignmentMutation = useUpdateAssignment(assignmentId);
 
   const { data, isLoading, error } = useGetAssignment(assignmentId);
 
+  console.log(data);
   useEffect(() => {
     if (!isLoading) {
       if (Array.isArray(data)) {
@@ -42,18 +44,14 @@ const AssignmentUpdate: React.FC<AssignmentUpdateProps> = ({
         setValue("title", data.title);
         setValue("content", data.content);
 
-        const startDate = data.startDate.toDate() as Date;
-        const endDate = data.endDate.toDate() as Date;
+        // 시간을 yyyy.mm.dd 로 불러오는 것 추후에 해야합니다.
 
-        const startDateString = startDate.toISOString().split("T")[0];
-        const endDateString = endDate.toISOString().split("T")[0];
-
-        // starDateString, endDateString 타입에러남 -> 추후 수정하겠습니다
-        setValue("startDate", startDateString);
-        setValue("endDate", endDateString);
+        // setValue("startDate", data.startDate);
+        // setValue("endDate", data.endDate);
       }
     }
-  }, [data, isLoading]);
+  }, [isOpen]);
+  // 일단 isOpen으로 해놓았지만 추후 변경해보자
 
   const onSubmit: SubmitHandler<Assignment> = async assignmentData => {
     // 이미지 파일들의 경로를 문자열 배열로 변환하여 data.images에 추가
@@ -143,9 +141,9 @@ const AssignmentUpdate: React.FC<AssignmentUpdateProps> = ({
           className="w-[245px] h-[40px] bg-white border rounded-xl text-grayscale-40 mb-[17px] pl-2"
         >
           <option className="text-grayscale-40">난이도를 선택해주세요</option>
-          <option value="상">상</option>
+          <option value="초">초</option>
           <option value="중">중</option>
-          <option value="하">하</option>
+          <option value="고">고</option>
         </select>
       </div>
 

--- a/src/hooks/mutation/useCreateAssignment.ts
+++ b/src/hooks/mutation/useCreateAssignment.ts
@@ -40,7 +40,7 @@ const createAssignment = async (
 
     const addAssignment = await addDoc(collection(db, "assignments"), {
       ...assignmentValue,
-      createdAt: serverTimestamp(), // 현재 시간을 타임스탬프로 설정하여 createdAt 필드에 추가
+      createdAt: serverTimestamp(),
       order: assignmentCount + 1,
       userId: userId,
     });

--- a/src/hooks/mutation/useUpdateAssignment.ts
+++ b/src/hooks/mutation/useUpdateAssignment.ts
@@ -1,32 +1,50 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { updateDoc, doc, DocumentReference } from "firebase/firestore";
+import { updateDoc, doc, serverTimestamp, Timestamp } from "firebase/firestore";
 import { db } from "@utils/firebase";
 import { Assignment } from "@/types/firebase.types";
 
 // Firestore 데이터 추가
-const updateAssignment = async (assignmentValue: Assignment) => {
+const updateAssignment = async (
+  assignmentValue: Assignment,
+  assignmentId: string,
+) => {
   try {
-    const updateAssignment = await updateDoc(
-      doc(db, "assignments", "assignmentValue.id"),//? 인자연결 안됨
-      { ...assignmentValue },
-    );
-    return updateAssignment;
+    if (typeof assignmentValue.startDate === "string") {
+      assignmentValue.startDate = Timestamp.fromDate(
+        new Date(assignmentValue.startDate),
+      );
+    }
+    if (typeof assignmentValue.endDate === "string") {
+      assignmentValue.endDate = Timestamp.fromDate(
+        new Date(assignmentValue.endDate),
+      );
+    }
+
+    await updateDoc(doc(db, "assignments", assignmentId), {
+      ...assignmentValue,
+      updatedAt: serverTimestamp(),
+    });
+    return assignmentValue;
   } catch (err) {
     console.log(err);
     throw err;
   }
 };
-//? updateAssignment에 인자 전달이 안됨
-const useUpdateAssignment = () => {
+
+const useUpdateAssignment = (assignmentId: string) => {
   const queryClient = useQueryClient();
-  const { mutate, isLoading, error } = useMutation(updateAssignment, {
-    onSuccess: () => {
-      queryClient.invalidateQueries(["getAssignment", ""]);
+  const { mutate, isLoading, error } = useMutation(
+    (assignmentValue: Assignment) =>
+      updateAssignment(assignmentValue, assignmentId),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["getAssignment", assignmentId || ""]);
+      },
+      onError: err => {
+        console.log(err);
+      },
     },
-    onError: err => {
-      console.log(err);
-    },
-  });
+  );
   return { mutate, isLoading, error };
 };
 


### PR DESCRIPTION
## 개요 :mag:

과제를 수정하고 데이터를 저장하고 변경된 값을 화면에 렌더링

## 작업사항 :memo:

- 수정된 과제를 데이터에 저장해주고, 변경된 값을 화면에 렌더링해줍니다. 
- 등록된 이미지 불러오는 것 추후 구현 예정 ✔️
- startDate, endDate -> yyyy.mm.dd 형태로 화면에 뿌려주는것도 다시 구현해보겠습니다. ✔️


close #212 

## 테스트 방법(optional)

각 값들을 수정하고 수정하기 버튼 누르면 변경된 데이터가 화면에 렌더링 됩니다.
파이어베이스에서도 데이터가 변경된 것 확인 가능 
