### PR TITLE
Feat: 등록된 과제 삭제하기

### DIFF
--- a/src/app/assignment/(components)/AssignmentDetailContent.tsx
+++ b/src/app/assignment/(components)/AssignmentDetailContent.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import React, { useState } from "react";
+import { useRouter } from "next/navigation";
 import AssignmentProfileImage from "../(components)/AssignmentProfileImage";
 import { useGetAssignment } from "@/hooks/queries/useGetAssignment";
+import { useDeleteRegisteredAssignment } from "@/hooks/mutation/useDeleteRegisteredAssignment";
 import { useParams } from "next/navigation";
-import Image from "next/image";
 import timestampToDate from "@/utils/timestampToDate";
 import LoadingSpinner from "@/components/Loading/Loading";
 import { User } from "@/types/firebase.types";
@@ -19,14 +20,15 @@ interface OwnProps {
 }
 
 const AssignmentDetailContent: React.FC<OwnProps> = ({ user }) => {
+  const router = useRouter();
+
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const { assignmentId } = useParams();
-
   const { data, isLoading, error } = useGetAssignment(assignmentId as string);
-
-  console.log("data", data);
-
+  const deleteAssignmentMutation = useDeleteRegisteredAssignment(
+    assignmentId as string,
+  );
   // const blob = data?.images; // FIXME: blob 이미지 호출 체크
   // console.log(blob);
 
@@ -151,7 +153,9 @@ const AssignmentDetailContent: React.FC<OwnProps> = ({ user }) => {
         title="강의를 삭제하시겠습니까?"
         confirmBtnMsg="삭제"
         onConfirm={() => {
+          deleteAssignmentMutation.mutate(assignmentId as string);
           setIsConfirmOpen(false);
+          router.push("/assignment");
         }}
         isOpen={isConfirmOpen}
         onCancel={() => {

--- a/src/app/assignment/(components)/AssignmentUpdate.tsx
+++ b/src/app/assignment/(components)/AssignmentUpdate.tsx
@@ -5,7 +5,6 @@ import { Assignment } from "@/types/firebase.types";
 import PageToast from "@/components/PageToast";
 import { useUpdateAssignment } from "@/hooks/mutation/useUpdateAssignment";
 import { useGetAssignment } from "@/hooks/queries/useGetAssignment";
-import timestampToDate from "@/utils/timestampToDate";
 
 interface AssignmentUpdateProps {
   isOpen: boolean;
@@ -31,10 +30,8 @@ const AssignmentUpdate: React.FC<AssignmentUpdateProps> = ({
   } = useForm<Assignment>();
 
   const updateAssignmentMutation = useUpdateAssignment(assignmentId);
-
   const { data, isLoading, error } = useGetAssignment(assignmentId);
 
-  console.log(data);
   useEffect(() => {
     if (!isLoading) {
       if (Array.isArray(data)) {

--- a/src/hooks/mutation/useDeleteRegisteredAssignment.ts
+++ b/src/hooks/mutation/useDeleteRegisteredAssignment.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { doc, deleteDoc } from "firebase/firestore";
+import { db } from "@utils/firebase";
+
+const deleteRegisteredAssignment = async (assignmentId: string) => {
+  try {
+    const deleteRegisteredAssignmentDoc = await deleteDoc(
+      doc(db, "assignments", assignmentId),
+    );
+    return deleteRegisteredAssignmentDoc;
+  } catch (err) {
+    console.log(err);
+    throw err;
+  }
+};
+
+const useDeleteRegisteredAssignment = (assignmentId: string) => {
+  const queryClient = useQueryClient();
+  const { mutate, isLoading, error } = useMutation(deleteRegisteredAssignment, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(["getAssignment", assignmentId]);
+    },
+    onError: err => {
+      console.log(err);
+    },
+  });
+  return { mutate, isLoading, error };
+};
+
+export { useDeleteRegisteredAssignment };


### PR DESCRIPTION
## 개요 :mag:

등록된 과제를 삭제하는 기능 구현

## 작업사항 :memo:

- 삭제버튼을 누르면 저장된 데이터 삭제
- 화면에서도 삭제되면서 /assignment 페이지로 넘어가도록 라우팅 

close #229 

## 테스트 방법(optional)

과제를 등록한 후 삭제를 시연해 보시면 됩니다. 

