### PR TITLE
Feat: 이전/다음 강의 기능 구현

### DIFF
--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureHeader.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureHeader.tsx
@@ -1,35 +1,25 @@
-import { Timestamp } from "firebase/firestore";
-import { FC, useState, useEffect } from "react";
-import { User } from "@/types/firebase.types";
-import timestampToDate from "@/utils/timestampToDate";
-import Image from "next/image";
+import { FC } from "react";
 import Link from "next/link";
-import { getMediaURL } from "@/hooks/lecture/useGetMediaURL";
+import Image from "next/image";
+
+import useGetLectureInfo from "@/hooks/queries/useGetLectureInfo";
+import useProfileImage from "@/hooks/lecture/useProfileImage";
 import UserImage from "@/app/classroom/(components)/modal/comment/UserImage";
+import timestampToDate from "@/utils/timestampToDate";
 
 interface LectureHeaderProps {
-  title: string;
-  startDate: Timestamp;
-  endDate: Timestamp;
-  user: User;
+  lectureId: string;
 }
 
-const LectureHeader: FC<LectureHeaderProps> = ({
-  title,
-  startDate,
-  endDate,
-  user,
-}) => {
-  const startDay = timestampToDate(startDate);
-  const endDay = timestampToDate(endDate);
+const LectureHeader: FC<LectureHeaderProps> = ({ lectureId }) => {
+  const { data, isFetching } = useGetLectureInfo(lectureId);
 
-  const [profileImageURL, setProfileImageURL] = useState<string | null>(null);
+  const { title, user } = data || {};
+  const { profileImage, username, role } = user || {};
+  const startDay = data?.startDate ? timestampToDate(data.startDate) : "";
+  const endDay = data?.endDate ? timestampToDate(data.endDate) : "";
 
-  useEffect(() => {
-    getMediaURL(user.profileImage)
-      .then(setProfileImageURL)
-      .catch(console.error);
-  }, [user.profileImage]);
+  const profileImageURL = useProfileImage(profileImage);
 
   return (
     <header className="flex border-b border-gray-200 w-full h-40">
@@ -45,23 +35,33 @@ const LectureHeader: FC<LectureHeaderProps> = ({
         </Link>
       </div>
       <div className="w-11/12 h-full flex flex-col justify-center">
-        <div className="flex flex-col mb-1">
-          <h1 className="text-xl font-semibold mb-1.5">{title}</h1>
-          <span className="text-gray-700 text-xs">
-            [수강기간]{startDay}~{endDay}
-          </span>
-        </div>
-        <div className="flex items-center mt-2">
-          {profileImageURL && <UserImage profileImage={profileImageURL} />}
-          <div className="flex items-center ml-2">
-            <span className=" text-sm font-semibold text-blue-500 ">
-              {user.username}
-            </span>
-            <span className="text-sm ml-1 text-gray-500">
-              &#183; {user.role}
-            </span>
-          </div>
-        </div>
+        {isFetching ? (
+          <div className="w-full h-full">Loading...</div>
+        ) : (
+          data && (
+            <>
+              <div className="flex flex-col mb-1">
+                <h1 className="text-xl font-semibold mb-1.5">{title}</h1>
+                <span className="text-gray-700 text-xs">
+                  [수강기간]{startDay}~{endDay}
+                </span>
+              </div>
+              <div className="flex items-center mt-2">
+                {profileImageURL && (
+                  <UserImage profileImage={profileImageURL} />
+                )}
+                <div className="flex items-center ml-2">
+                  <span className=" text-sm font-semibold text-blue-500 ">
+                    {username}
+                  </span>
+                  <span className="text-sm ml-1 text-gray-500">
+                    &#183; {role}
+                  </span>
+                </div>
+              </div>
+            </>
+          )
+        )}
       </div>
     </header>
   );

--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureNavigation.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureNavigation.tsx
@@ -1,28 +1,49 @@
-import Image from "next/image";
+import React, { FC } from "react";
 
-const LectureNavigation = () => {
+import useGetPreAndNextLectureInfo from "@/hooks/queries/useGetPreAndNextLectureInfo";
+import NavigationButton from "./NavigationButton";
+
+interface LectureNavigationProps {
+  lectureId: string;
+}
+
+const LectureNavigation: FC<LectureNavigationProps> = ({ lectureId }) => {
+  const { data, isFetching, error } = useGetPreAndNextLectureInfo(lectureId);
+  const { prevLectureId, nextLectureId } = data || {};
+
+  console.log(data, isFetching, error);
+
+  if (error instanceof Error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  if (isFetching || !data) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <nav className="flex justify-between items-center p-10 h-24 text-gray-500">
-      <button className="flex items-center cursor-pointer">
-        <Image
-          src="/images/backward-step.svg"
-          alt="이전강의"
-          width={20}
-          height={20}
-          className="cursor-pointer m-2"
+      {prevLectureId ? (
+        <NavigationButton
+          lectureId={prevLectureId}
+          imageSrc="/images/backward-step.svg"
+          altText="이전강의"
+          buttonText="이전강의"
         />
-        <span className="text-sm m-2 ">이전강의</span>
-      </button>
-      <button className="flex items-center cursor-pointer">
-        <Image
-          src="/images/forward-step.svg"
-          alt="다음강의"
-          width={20}
-          height={20}
-          className="cursor-pointer m-2"
+      ) : (
+        <div />
+      )}
+
+      {nextLectureId ? (
+        <NavigationButton
+          lectureId={nextLectureId}
+          imageSrc="/images/forward-step.svg"
+          altText="다음강의"
+          buttonText="다음강의"
         />
-        <span className="text-sm m-2">다음강의</span>
-      </button>
+      ) : (
+        <div />
+      )}
     </nav>
   );
 };

--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/NavigationButton.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/NavigationButton.tsx
@@ -1,0 +1,39 @@
+import React, { FC } from "react";
+import { useRouter } from "next/navigation";
+import Image from "next/image";
+
+interface NavigationButtonProps {
+  lectureId: string | null | undefined;
+  imageSrc: string;
+  altText: string;
+  buttonText: string;
+}
+
+const NavigationButton: FC<NavigationButtonProps> = ({
+  lectureId,
+  imageSrc,
+  altText,
+  buttonText,
+}) => {
+  const router = useRouter();
+
+  return (
+    lectureId && (
+      <button
+        onClick={() => lectureId && router.push(`/classroom/${lectureId}`)}
+        className="flex items-center cursor-pointer"
+      >
+        <Image
+          src={imageSrc}
+          alt={altText}
+          width={20}
+          height={20}
+          className="cursor-pointer m-2"
+        />
+        <span className="text-sm m-2 ">{buttonText}</span>
+      </button>
+    )
+  );
+};
+
+export default NavigationButton;

--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/typesOf/LectureContent.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/typesOf/LectureContent.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from "react";
+import useGetLectureInfo from "@/hooks/queries/useGetLectureInfo";
+
+import VideoLecture from "./VideoLecture";
+import NoteLecture from "./NoteLecture";
+import LinkLecture from "./LinkLecture";
+
+interface LectureContentProps {
+  type: string;
+  content: object;
+}
+
+const LectureContent: FC<LectureContentProps> = ({ type, content }) => {
+  switch (type) {
+    case "비디오":
+      return <VideoLecture content={content} />;
+    case "노트":
+      return <NoteLecture content={content} />;
+    case "링크":
+      return <LinkLecture content={content} />;
+    default:
+      return <div>Invalid lecture type</div>;
+  }
+};
+
+export default LectureContent;

--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/typesOf/TypeOfLecture.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/typesOf/TypeOfLecture.tsx
@@ -1,25 +1,22 @@
 import React, { FC } from "react";
-import VideoLecture from "./VideoLecture";
-import NoteLecture from "./NoteLecture";
-import LinkLecture from "./LinkLecture";
-import type { LectureContent } from "@/types/firebase.types";
+
+import useGetLectureInfo from "@/hooks/queries/useGetLectureInfo";
+import LectureContent from "./LectureContent";
 
 interface TypeOfLectureProps {
-  type: string;
-  content: LectureContent;
+  lectureId: string;
 }
 
-const TypeOfLecture: FC<TypeOfLectureProps> = ({ type, content }) => {
-  switch (type) {
-    case "비디오":
-      return <VideoLecture content={content} />;
-    case "노트":
-      return <NoteLecture content={content} />;
-    case "링크":
-      return <LinkLecture content={content} />;
-    default:
-      return <div>Invalid lecture type</div>;
+const TypeOfLecture: FC<TypeOfLectureProps> = ({ lectureId }) => {
+  const { data } = useGetLectureInfo(lectureId);
+
+  if (!data || data.lectureContent === undefined) {
+    return <div>Loading...</div>;
   }
+
+  const { lectureType: type, lectureContent: content } = data;
+
+  return <LectureContent type={type} content={content} />;
 };
 
 export default TypeOfLecture;

--- a/src/app/classroom/[lectureId]/page.tsx
+++ b/src/app/classroom/[lectureId]/page.tsx
@@ -1,45 +1,26 @@
 "use client";
 
-import React, { FC, use } from "react";
+import React from "react";
 
 import LectureHeader from "@/app/classroom/[lectureId]/(components)/lectureRoom/LectureHeader";
 import TypeOfLecture from "@/app/classroom/[lectureId]/(components)/lectureRoom/typesOf/TypeOfLecture";
 import LectureComment from "@/app/classroom/[lectureId]/(components)/lectureRoom/LectureComment";
 import LectureNavigation from "@/app/classroom/[lectureId]/(components)/lectureRoom/LectureNavigation";
-import useGetLectureInfo from "@/hooks/queries/useGetLectureInfo";
-
-interface lectureIdProps {
-  lectureId: string;
-}
 
 const LectureHome = ({ params }: { params: { lectureId: string } }) => {
   const { lectureId } = params;
-  const { data, isLoading, error, isFetching } = useGetLectureInfo(lectureId);
-
-  if (isFetching) {
-    return <div className="w-full h-full">Loading...</div>;
-  } else if (!isFetching && data !== undefined && data.user) {
-    return (
-      <main className="lectuerContainer flex flex-col w-full h-full">
-        <LectureHeader
-          title={data.title}
-          startDate={data.startDate}
-          endDate={data.endDate}
-          user={data.user}
-        />
-        <div className="mainContainer flex w-full h-screen">
-          <div className="Container flex flex-col w-3/4">
-            <TypeOfLecture
-              type={data.lectureType}
-              content={data.lectureContent}
-            />
-            <LectureNavigation />
-          </div>
-          <LectureComment lectureId={lectureId} />
+  return (
+    <main className="lectuerContainer flex flex-col w-full h-full">
+      <LectureHeader lectureId={lectureId} />
+      <div className="mainContainer flex w-full h-screen">
+        <div className="Container flex flex-col w-3/4">
+          <TypeOfLecture lectureId={lectureId} />
+          <LectureNavigation lectureId={lectureId} />
         </div>
-      </main>
-    );
-  }
+        <LectureComment lectureId={lectureId} />
+      </div>
+    </main>
+  );
 };
 
 export default LectureHome;

--- a/src/hooks/lecture/useProfileImage.ts
+++ b/src/hooks/lecture/useProfileImage.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from "react";
+import { getMediaURL } from "@/hooks/lecture/useGetMediaURL";
+
+const useProfileImage = (profileImage: string | undefined) => {
+  const [profileImageURL, setProfileImageURL] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (profileImage) {
+      getMediaURL(profileImage).then(setProfileImageURL).catch(console.error);
+    }
+  }, [profileImage]);
+
+  return profileImageURL;
+};
+
+export default useProfileImage;

--- a/src/hooks/queries/useGetPreAndNextLectureInfo.ts
+++ b/src/hooks/queries/useGetPreAndNextLectureInfo.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { db } from "@/utils/firebase";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  where,
+} from "firebase/firestore";
+
+function useGetPreAndNextLectureInfo(lectureId: string) {
+  return useQuery(["lectureNavigation", lectureId], async () => {
+    const lectureSnap = await getDoc(doc(db, "lectures", lectureId));
+
+    const data = lectureSnap.data() as { courseId: string; order: number };
+    const { courseId, order: currentOrder } = data;
+
+    const prevLectureQuery = query(
+      collection(db, "lectures"),
+      where("courseId", "==", courseId),
+      where("order", "<", currentOrder),
+      orderBy("order", "desc"),
+      limit(1),
+    );
+    const prevLectureSnapshot = await getDocs(prevLectureQuery);
+    const prevLectureId = prevLectureSnapshot.docs[0]?.id || null;
+
+    const nextLectureQuery = query(
+      collection(db, "lectures"),
+      where("courseId", "==", courseId),
+      where("order", ">", currentOrder),
+      orderBy("order"),
+      limit(1),
+    );
+    const nextLectureSnapshot = await getDocs(nextLectureQuery);
+    const nextLectureId = nextLectureSnapshot.docs[0]?.id || null;
+
+    return { prevLectureId, nextLectureId };
+  });
+}
+
+export default useGetPreAndNextLectureInfo;


### PR DESCRIPTION
## 개요 :mag:

이전/다음 강의 기능 구현,
페이지 요청이 왔을 때, lectureId를 토대로 이전/다음 강의를 구하는 함수를 만들어 적절히 렌더링 할 수 있도록 함.
또한 작업을 하면서 컴포넌트에게 확실한 기능을 주는 리팩토링 작업을 진행(강의장 헤터, 네비, 메인)

## 작업사항 :memo:

close #235 

## 테스트 방법(optional)

