### PR TITLE
Feat: 강의 목록에서 각 강의 수정 버튼 클릭시 해당 모달창 open 구현

### DIFF
--- a/src/app/classroom/(components)/ClassContent.tsx
+++ b/src/app/classroom/(components)/ClassContent.tsx
@@ -23,7 +23,11 @@ const ClassContent = ({ currentCourse }: IProps) => {
 
   const handleModalOpen = () => {
     dispatch(
-      setModalVisibility({ modalName: "lectureTypeModalOpen", visible: true }),
+      setModalVisibility({
+        modalName: "lectureTypeModalOpen",
+        visible: true,
+        modalRole: "create",
+      }),
     );
   };
 

--- a/src/app/classroom/(components)/main/ContentCard.tsx
+++ b/src/app/classroom/(components)/main/ContentCard.tsx
@@ -6,9 +6,12 @@ import thumnail from "../../../../../public/images/thumnail.png";
 import { convertSecondsToMinute } from "@/utils/convertSecondsToMinute";
 import LectureDeleteModal from "../modal/createLecture/LectureDeleteModal";
 import { useState } from "react";
+import { useDispatch } from "react-redux";
+import { setModalVisibility } from "@/redux/slice/classroomModalSlice";
 
 const ContentCard = ({ lecture }: { lecture: ILecture }) => {
   const router = useRouter();
+  const dispatch = useDispatch();
   const handleMovePage = () => {
     router.push(`/classroom/${lecture.lectureId}`);
   };
@@ -35,10 +38,24 @@ const ContentCard = ({ lecture }: { lecture: ILecture }) => {
       time: "",
     },
   };
+  const MODAL_OBJ: { [key: string]: string } = {
+    노트: "noteModalOpen",
+    링크: "linkModalOpen",
+    비디오: "videoFileModalOpen",
+  };
   const [deleteModal, setDeleteModal] = useState(false);
   const handleDeleteModal = () => {
     //강의 삭제 로직 구현하시면 됩니당
     setDeleteModal(false);
+  };
+  const handleEditLectureModal = () => {
+    dispatch(
+      setModalVisibility({
+        modalName: MODAL_OBJ[lectureType],
+        visible: true,
+        modalRole: "edit",
+      }),
+    );
   };
 
   return (
@@ -52,7 +69,9 @@ const ContentCard = ({ lecture }: { lecture: ILecture }) => {
       </div>
       <div className="w-2/3 h-5/6 ml-20px flex flex-col">
         <div className="text-xs ml-auto flex items-center w-[60px] text-grayscale-100 justify-around text-[12px]">
-          <button className="text-xs">수정</button>
+          <button className="text-xs" onClick={handleEditLectureModal}>
+            수정
+          </button>
           <div className="w-[0.5px] h-3 border-[0.5px] border-black"></div>
           <button className="text-xs">삭제</button>
         </div>

--- a/src/app/classroom/(components)/modal/createLecture/AddLinkModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/AddLinkModal.tsx
@@ -9,12 +9,13 @@ import useLectureInfo from "@/hooks/lecture/useLectureInfo";
 
 const AddLinkModal: React.FC = () => {
   const dispatch = useDispatch();
-  const { handleModalMove } = useClassroomModal();
+  const { modalRole, handleModalMove } = useClassroomModal();
   const { externalLink } = useLectureInfo();
-
-  const prevModal = () => {
-    handleModalMove("lectureTypeModalOpen", "linkModalOpen");
+  const MODAL_ROLE_OBJ: { [key: string]: string } = {
+    create: "링크 만들기",
+    edit: "수정하기",
   };
+
   const [errorMessage, setErrorMessage] = useState("");
 
   const handleInputContent = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -39,13 +40,18 @@ const AddLinkModal: React.FC = () => {
 
   return (
     <Layout>
-      <ModalHeader currentModalName={"링크 만들기"}>
-        <button
-          onClick={prevModal}
-          className="text-xl font-bold text-grayscale-100"
-        >
-          강의 만들기
-        </button>
+      <ModalHeader currentModalName={MODAL_ROLE_OBJ[modalRole]}>
+        {modalRole === "create" ? (
+          <button
+            onClick={() =>
+              handleModalMove("lectureTypeModalOpen", "linkModalOpen")
+            }
+          >
+            강의 만들기
+          </button>
+        ) : (
+          <span>강의 수정</span>
+        )}
       </ModalHeader>
       <ModalMain>
         <label htmlFor="externalLink" className="hidden" />

--- a/src/app/classroom/(components)/modal/createLecture/AddNoteModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/AddNoteModal.tsx
@@ -9,18 +9,26 @@ const NoSsrEditor = dynamic(() => import("./NoteSection"), {
 });
 
 const AddNoteModal: React.FC = () => {
-  const { handleModalMove } = useClassroomModal();
+  const { modalRole, handleModalMove } = useClassroomModal();
+  const MODAL_ROLE_OBJ: { [key: string]: string } = {
+    create: "노트 만들기",
+    edit: "수정하기",
+  };
 
   return (
     <Layout>
-      <ModalHeader currentModalName={"노트 만들기"}>
-        <button
-          onClick={() =>
-            handleModalMove("lectureTypeModalOpen", "noteModalOpen")
-          }
-        >
-          강의 만들기
-        </button>
+      <ModalHeader currentModalName={MODAL_ROLE_OBJ[modalRole]}>
+        {modalRole === "create" ? (
+          <button
+            onClick={() =>
+              handleModalMove("lectureTypeModalOpen", "noteModalOpen")
+            }
+          >
+            강의 만들기
+          </button>
+        ) : (
+          <span>강의 수정</span>
+        )}
       </ModalHeader>
       <ModalMain>
         <NoSsrEditor />

--- a/src/app/classroom/(components)/modal/createLecture/AddVideoFileModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/AddVideoFileModal.tsx
@@ -25,8 +25,12 @@ const AddVideoFileModal: React.FC = () => {
   const successMessage = useSelector(
     (state: RootState) => state.dropzoneFile.successMessage,
   );
-  const { handleModalMove } = useClassroomModal();
+  const { modalRole, handleModalMove } = useClassroomModal();
   const { handleRemoveVideoFile } = useVideoFileDrop();
+  const MODAL_ROLE_OBJ: { [key: string]: string } = {
+    create: "영상 강의 만들기",
+    edit: "수정하기",
+  };
 
   useEffect(() => {
     if (videoFileName) {
@@ -41,14 +45,18 @@ const AddVideoFileModal: React.FC = () => {
 
   return (
     <Layout>
-      <ModalHeader currentModalName={"영상 강의 만들기"}>
-        <button
-          onClick={() =>
-            handleModalMove("lectureTypeModalOpen", "videoFileModalOpen")
-          }
-        >
-          강의 만들기
-        </button>
+      <ModalHeader currentModalName={MODAL_ROLE_OBJ[modalRole]}>
+        {modalRole === "create" ? (
+          <button
+            onClick={() =>
+              handleModalMove("lectureTypeModalOpen", "videoFileModalOpen")
+            }
+          >
+            강의 만들기
+          </button>
+        ) : (
+          <span>강의 수정</span>
+        )}
       </ModalHeader>
       <ModalMain>
         <div className="flex flex-col gap-5 h-72">

--- a/src/hooks/lecture/useClassroomModal.tsx
+++ b/src/hooks/lecture/useClassroomModal.tsx
@@ -23,10 +23,25 @@ const useClassroomModal = () => {
   const replyCommentModalOpen = useSelector(
     (state: RootState) => state.classroomModal.replyCommentModalOpen,
   );
+  const modalRole = useSelector(
+    (state: RootState) => state.classroomModal.modalRole,
+  );
 
   const handleModalMove = (openModalName: string, closeModalName: string) => {
-    dispatch(setModalVisibility({ modalName: openModalName, visible: true }));
-    dispatch(setModalVisibility({ modalName: closeModalName, visible: false }));
+    dispatch(
+      setModalVisibility({
+        modalName: openModalName,
+        visible: true,
+        modalRole: "create",
+      }),
+    );
+    dispatch(
+      setModalVisibility({
+        modalName: closeModalName,
+        visible: false,
+        modalRole: "create",
+      }),
+    );
   };
 
   return {
@@ -36,6 +51,7 @@ const useClassroomModal = () => {
     videoFileModalOpen,
     commentModalOpen,
     replyCommentModalOpen,
+    modalRole,
     handleModalMove,
   };
 };

--- a/src/redux/slice/classroomModalSlice.tsx
+++ b/src/redux/slice/classroomModalSlice.tsx
@@ -8,6 +8,7 @@ interface ModalState {
   commentModalOpen: boolean;
   replyCommentModalOpen: boolean;
   lectureId: string | null;
+  modalRole: string;
   [key: string]: boolean | string | null;
 }
 
@@ -19,6 +20,7 @@ const initialState: ModalState = {
   commentModalOpen: false,
   replyCommentModalOpen: false,
   lectureId: null,
+  modalRole: "",
 };
 
 const classroomModalSlice = createSlice({
@@ -27,10 +29,15 @@ const classroomModalSlice = createSlice({
   reducers: {
     setModalVisibility: (
       state,
-      action: PayloadAction<{ modalName: string; visible: boolean }>,
+      action: PayloadAction<{
+        modalName: string;
+        visible: boolean;
+        modalRole: string;
+      }>,
     ) => {
-      const { modalName, visible } = action.payload;
+      const { modalName, visible, modalRole } = action.payload;
       state[modalName] = visible;
+      state.modalRole = modalRole;
     },
     closeModal: () => initialState,
   },


### PR DESCRIPTION
## 개요 :mag:
*  클래스룸 모달창의 역할 구별을 위한 상태 추가(강의추가 or 강의수정)
* 모달창의 역할에 따라 모달창 제목을 다르게 띄우도록 구현
  * 강의 추가시 모달창 제목 : `강의 만들기 ▶ 노트/링크/영상 강의 만들기`
  * 강의 수정시 모달창 제목 : `강의 수정 ▶ 수정`
  * 강의 추가시에는 브래드크럼 클릭시 이전모달로 이동가능, 강의 수정시에는 불가능(이동할 모달이 없으므로)
* 강의 목록에서 각 강의 수정 버튼 클릭시 해당 모달창이 열리도록 구현

## 작업사항 :memo:
* close #247 
