### PR TITLE
Refactor: 유저 이미지 중복 함수 수정 및 타입 에러 수정

### DIFF
--- a/src/app/classroom/(components)/modal/comment/UserImage.tsx
+++ b/src/app/classroom/(components)/modal/comment/UserImage.tsx
@@ -1,6 +1,5 @@
-import React, { FC, useState, useEffect } from "react";
+import React, { FC } from "react";
 import Image from "next/image";
-import { getMediaURL } from "@/hooks/lecture/useGetMediaURL";
 import thumbnail from "../../../../../../public/images/thumnail.png";
 
 interface UserImageProps {
@@ -9,20 +8,12 @@ interface UserImageProps {
 }
 
 const UserImage: FC<UserImageProps> = ({ profileImage, size = "default" }) => {
-  const [profileImageURL, setProfileImageURL] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (profileImage) {
-      getMediaURL(profileImage).then(setProfileImageURL).catch(console.error);
-    }
-  }, [profileImage]);
-
   const wrapperClass = size === "default" ? "w-7 h-7" : "w-10 h-10";
 
   return (
     <div className={`${wrapperClass} relative rounded-full flex-shrink-0`}>
       <Image
-        src={profileImageURL || thumbnail}
+        src={profileImage || thumbnail}
         alt="사용자 이미지"
         sizes="(max-width: 768px) 100vw"
         fill={true}

--- a/src/app/classroom/(components)/modal/comment/UserInfo.tsx
+++ b/src/app/classroom/(components)/modal/comment/UserInfo.tsx
@@ -1,16 +1,30 @@
 import React from "react";
 
 interface UserInfoProps {
-  username: string;
+  username: string | undefined;
   role?: string;
   isForm?: boolean;
+  isHeader?: boolean;
 }
 
-const UserInfo: React.FC<UserInfoProps> = ({ username, role, isForm }) => (
-  <div className="flex items-center mb-1">
-    <span className={isForm ? "" : "font-semibold "}>{username}</span>
-    <span className="text-sm ml-1 text-gray-500 font-light">&#183; {role}</span>
-  </div>
-);
-
+const UserInfo: React.FC<UserInfoProps> = ({
+  username,
+  role,
+  isForm,
+  isHeader,
+}) => {
+  return isHeader ? (
+    <div className="flex items-center ml-2">
+      <span className=" text-sm font-semibold text-blue-500 ">{username}</span>
+      <span className="text-sm ml-1 text-gray-500">&#183; {role}</span>
+    </div>
+  ) : (
+    <div className="flex items-center mb-1">
+      <span className={isForm ? "" : "font-semibold "}>{username}</span>
+      <span className="text-sm ml-1 text-gray-500 font-light">
+        &#183; {role}
+      </span>
+    </div>
+  );
+};
 export default UserInfo;

--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureComment.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureComment.tsx
@@ -17,18 +17,26 @@ const LectureComment: FC<LectureCommentProps> = ({ lectureId }) => {
   const handleCommentClick = (id: string) => {
     setSelectedCommentId(id);
     dispatch(
-      setModalVisibility({ modalName: "replyCommentModalOpen", visible: true }),
+      setModalVisibility({
+        modalName: "replyCommentModalOpen",
+        visible: true,
+        modalRole: "create",
+      }),
     );
   };
 
   const handleButtonClick = () => {
     dispatch(
-      setModalVisibility({ modalName: "commentModalOpen", visible: true }),
+      setModalVisibility({
+        modalName: "commentModalOpen",
+        visible: true,
+        modalRole: "create",
+      }),
     );
   };
 
   return (
-    <section className="CommunityContainer bg-gray-100 w-1/4 float-right h-[740px]">
+    <section className="CommunityContainer bg-gray-100 w-1/4 float-right h-full">
       <header className="m-3 flex content-center justify-between items-center h-[50px]">
         <h1 className="text-center text-xl font-semibold pl-2">
           강의 커뮤니티
@@ -40,7 +48,7 @@ const LectureComment: FC<LectureCommentProps> = ({ lectureId }) => {
           작성
         </button>
       </header>
-      <main className="overflow-y-auto h-[600px] pb-[60px]">
+      <main className="overflow-y-auto h-5/6 pb-[50px]">
         <CommentsSection
           lectureId={lectureId}
           onCommentClick={handleCommentClick}

--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureHeader.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureHeader.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import useGetLectureInfo from "@/hooks/queries/useGetLectureInfo";
 import UserImage from "@/app/classroom/(components)/modal/comment/UserImage";
 import timestampToDate from "@/utils/timestampToDate";
-import MiniLoadingSpinner from "@/components/Loading/MiniLoadingSpinner";
+import UserInfo from "@/app/classroom/(components)/modal/comment/UserInfo";
 
 interface LectureHeaderProps {
   lectureId: string;
@@ -46,14 +46,7 @@ const LectureHeader: FC<LectureHeaderProps> = ({ lectureId }) => {
               </div>
               <div className="flex items-center mt-2">
                 <UserImage profileImage={profileImage} />
-                <div className="flex items-center ml-2">
-                  <span className=" text-sm font-semibold text-blue-500 ">
-                    {username}
-                  </span>
-                  <span className="text-sm ml-1 text-gray-500">
-                    &#183; {role}
-                  </span>
-                </div>
+                <UserInfo username={username} role={role} isHeader={true} />
               </div>
             </>
           )


### PR DESCRIPTION
## 개요 :mag:

강의장 헤더에서 강의를 작성한 User 정보를 가져올 때 유저 이미지를 가져오는 함수가 중복된 점을 발견하여 수정
또한 강의 커뮤니티 섹션은 LectureComment 부분에서 setModalVisibility의 타입에러를 발견하고 수정
마지막으로 강의장 layout 안맞던 부분 수정

## 작업사항 :memo:

close #257 

## 테스트 방법(optional)


