### PR TITLE
Update: 비공개 여부에 따른 강의장 이동 및 댓글, 답글 모달 닫힘 여부

### DIFF
--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureComment.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/LectureComment.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect, useRef } from "react";
+import React, { FC, useState } from "react";
 import { useDispatch } from "react-redux";
 import { setModalVisibility } from "@/redux/slice/classroomModalSlice";
 import ReplySection from "@/app/classroom/(components)/modal/comment/ReplySection";

--- a/src/app/classroom/[lectureId]/(components)/lectureRoom/typesOf/LectureContent.tsx
+++ b/src/app/classroom/[lectureId]/(components)/lectureRoom/typesOf/LectureContent.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from "react";
-import useGetLectureInfo from "@/hooks/queries/useGetLectureInfo";
 
 import VideoLecture from "./VideoLecture";
 import NoteLecture from "./NoteLecture";

--- a/src/hooks/mutation/useDeleteComment.ts
+++ b/src/hooks/mutation/useDeleteComment.ts
@@ -4,17 +4,16 @@ import { useDispatch } from "react-redux";
 import {
   collection,
   doc,
-  deleteDoc,
   query,
   where,
   getDocs,
-  DocumentData,
   runTransaction,
 } from "firebase/firestore";
 import { setModalVisibility } from "@/redux/slice/classroomModalSlice";
 
 const deleteCommentFromDB = async (commentId: string) => {
   const commentRef = doc(db, "lectureComments", commentId);
+  let isComment;
 
   await runTransaction(db, async transaction => {
     const commentSnap = await transaction.get(commentRef);
@@ -23,6 +22,8 @@ const deleteCommentFromDB = async (commentId: string) => {
     }
 
     const comment = commentSnap.data();
+    isComment = !comment.parentId;
+
     if (comment.parentId) {
       const parentCommentRef = doc(db, "lectureComments", comment.parentId);
       const parentCommentSnapshot = await transaction.get(parentCommentRef);
@@ -46,6 +47,8 @@ const deleteCommentFromDB = async (commentId: string) => {
       transaction.delete(reply.ref);
     });
   });
+
+  return isComment;
 };
 
 export const useDeleteComment = () => {
@@ -53,17 +56,24 @@ export const useDeleteComment = () => {
   const queryClient = useQueryClient();
 
   return useMutation(deleteCommentFromDB, {
-    onSuccess: () => {
+    onSuccess: isComment => {
       queryClient.invalidateQueries(["comments"]);
-      dispatch(
-        setModalVisibility({ modalName: "commentModalOpen", visible: false }),
-      );
-      dispatch(
-        setModalVisibility({
-          modalName: "replyCommentModalOpen",
-          visible: false,
-        }),
-      );
+      if (isComment) {
+        dispatch(
+          setModalVisibility({
+            modalName: "commentModalOpen",
+            visible: false,
+            modalRole: "edit",
+          }),
+        );
+        dispatch(
+          setModalVisibility({
+            modalName: "replyCommentModalOpen",
+            visible: false,
+            modalRole: "edit",
+          }),
+        );
+      }
     },
   });
 };


### PR DESCRIPTION
## 개요 :mag:

1. 강의 중에서 비공개 강의가 존재할 경우, 강의장에서 비공개 강의는 건너뛰고 이전/다음 강의로 넘어감.
2. 이전에는 댓글과 답글을 삭제할 경우 둘 다 모달이 닫혔지만, 답글을 삭제할 경우 모달이 유지되도록 수정.

## 작업사항 :memo:

close #263 

## 테스트 방법(optional)


