### PR TITLE
Feat: 과제 등록 이미지 storage에 저장

### DIFF
--- a/src/app/assignment/(components)/AssignmentCreate.tsx
+++ b/src/app/assignment/(components)/AssignmentCreate.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { Assignment } from "@/types/firebase.types";
 import PageToast from "@/components/PageToast";
 import { useCreateAssignment } from "@/hooks/mutation/useCreateAssignment";
+import useImageUpload from "@/hooks/mutation/useUpdateImage";
 
 interface AssignmentCreateProps {
   isOpen: boolean;
@@ -26,6 +27,7 @@ const AssignmentCreate: React.FC<AssignmentCreateProps> = ({
   } = useForm<Assignment>();
 
   const createAssignmentMutation = useCreateAssignment();
+  const imageUploadMutation = useImageUpload();
 
   const onSubmit: SubmitHandler<Assignment> = async assignmentData => {
     // 이미지 파일들의 경로를 문자열 배열로 변환하여 data.images에 추가
@@ -33,6 +35,14 @@ const AssignmentCreate: React.FC<AssignmentCreateProps> = ({
     assignmentData.readStudents = [];
 
     try {
+      //이미지등록코드
+      const uploadPromises = imageFiles.map(file =>
+        imageUploadMutation.mutateAsync(file),
+      );
+      const uploadedUrls = await Promise.all(uploadPromises);
+      assignmentData.images = uploadedUrls;
+      //이미지등록코드
+
       createAssignmentMutation.mutate(assignmentData);
 
       setToastMsg("과제가 성공적으로 등록되었습니다.");

--- a/src/hooks/mutation/useUpdateImage.ts
+++ b/src/hooks/mutation/useUpdateImage.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { storage } from "@utils/firebase";
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
+
+const useImageUpload = () => {
+  const uploadImage = async (file: File) => {
+    const storageRef = ref(storage, `assignments/images/${file.name}`); // storage 모듈 사용
+    await uploadBytes(storageRef, file);
+    const url = await getDownloadURL(storageRef);
+    return url;
+  };
+
+  return useMutation(uploadImage);
+};
+
+export default useImageUpload;


### PR DESCRIPTION
## 개요 :mag:

과제 등록/ 수정 이미지 storage에 저장 


## 작업사항 :memo:

- 과제 등록시 storage -> assignments/images에 이미지가 저장됩니다.
- 과제 수정시에 등록된 이미지를 화면에 불러와 줍니다. 
- 과제 수정할 때 새로운 이미지를 등록하면 이전 데이터가 날아가는 오류 있음 -> 수정해야함 

close #271 

## 테스트 방법(optional)

과제등록/ 수정부분에서 확인 가능합니다. 
