### PR TITLE
Feat: Intl API를 활용한 timestamp formatting 외

### DIFF
--- a/src/app/assignment/(components)/AssignmentDetailContent.tsx
+++ b/src/app/assignment/(components)/AssignmentDetailContent.tsx
@@ -6,7 +6,6 @@ import AssignmentProfileImage from "../(components)/AssignmentProfileImage";
 import { useGetAssignment } from "@/hooks/queries/useGetAssignment";
 import { useDeleteRegisteredAssignment } from "@/hooks/mutation/useDeleteRegisteredAssignment";
 import { useParams } from "next/navigation";
-import timestampToDate from "@/utils/timestampToDate";
 import LoadingSpinner from "@/components/Loading/Loading";
 import { User } from "@/types/firebase.types";
 import { Assignment } from "@/types/firebase.types";
@@ -14,6 +13,7 @@ import { Assignment } from "@/types/firebase.types";
 import AssignmentGlobalConfirmDialog from "./AssignmentGlobalConfirmDialog";
 import AssignmentModal from "./AssignmentModal";
 import AssignmentUpdate from "./AssignmentUpdate";
+import timestampToIntlDate from "@/utils/timestampToIntlDate";
 
 interface OwnProps {
   user: User;
@@ -47,6 +47,8 @@ const AssignmentDetailContent: React.FC<OwnProps> = ({ user }) => {
   }
   const assignment: Assignment = Array.isArray(data) ? data[0] : data;
 
+  console.log("assignment", assignment.createdAt);
+
   return (
     <div>
       {data ? (
@@ -74,7 +76,9 @@ const AssignmentDetailContent: React.FC<OwnProps> = ({ user }) => {
                   {assignment.user?.role}
                 </span>
                 <span className="text-grayscale-40 text-[14px] font-[500]">
-                  {timestampToDate(assignment.createdAt)}
+                  {assignment.createdAt
+                    ? timestampToIntlDate(assignment.createdAt, "/")
+                    : null}
                 </span>
               </div>
             </div>
@@ -144,7 +148,7 @@ const AssignmentDetailContent: React.FC<OwnProps> = ({ user }) => {
               </span>
               <span className="w-[5px] h-[5px] bg-grayscale-20 rounded-full"></span>
               <span className="text-grayscale-40 text-[14px] font-[500]">
-                {timestampToDate(assignment.endDate)}
+                {timestampToIntlDate(assignment.endDate, "/")}
               </span>
             </div>
           </div>

--- a/src/app/assignment/(components)/AssignmentDetailContent.tsx
+++ b/src/app/assignment/(components)/AssignmentDetailContent.tsx
@@ -9,11 +9,13 @@ import { useParams } from "next/navigation";
 import LoadingSpinner from "@/components/Loading/Loading";
 import { User } from "@/types/firebase.types";
 import { Assignment } from "@/types/firebase.types";
+import Image from "next/image";
 
 import AssignmentGlobalConfirmDialog from "./AssignmentGlobalConfirmDialog";
 import AssignmentModal from "./AssignmentModal";
 import AssignmentUpdate from "./AssignmentUpdate";
 import timestampToIntlDate from "@/utils/timestampToIntlDate";
+import emptyArrayCheck from "@/utils/emptyArrayCheck";
 
 interface OwnProps {
   user: User;
@@ -27,7 +29,7 @@ const AssignmentDetailContent: React.FC<OwnProps> = ({ user }) => {
   const { assignmentId } = useParams();
   const { data, isLoading, error } = useGetAssignment(assignmentId as string);
 
-  // console.log("data", data);
+  console.log("assignmentDetailData", data);
 
   const deleteAssignmentMutation = useDeleteRegisteredAssignment(
     assignmentId as string,
@@ -46,8 +48,6 @@ const AssignmentDetailContent: React.FC<OwnProps> = ({ user }) => {
     return null;
   }
   const assignment: Assignment = Array.isArray(data) ? data[0] : data;
-
-  console.log("assignment", assignment.createdAt);
 
   return (
     <div>
@@ -131,17 +131,6 @@ const AssignmentDetailContent: React.FC<OwnProps> = ({ user }) => {
             <p className="text-grayscale-60 text-[14px] font-[400]">
               {assignment.content}
             </p>
-            {/* {assignment.images.map((image, index) => {
-            return (
-              <Image
-                key={index}
-                src={URL.createObjectURL(image)}
-                alt={"이미지추가"}
-                width={61}
-                height={61}
-              />
-            );
-          })} */}
             <div className="flex justify-end items-center pt-[5px] gap-[7px]">
               <span className="text-grayscale-60 text-[14px] font-[500]">
                 마감일
@@ -151,6 +140,24 @@ const AssignmentDetailContent: React.FC<OwnProps> = ({ user }) => {
                 {timestampToIntlDate(assignment.endDate, "/")}
               </span>
             </div>
+            {!emptyArrayCheck(assignment.images) ? (
+              <div className="pt-[34px]">
+                {assignment.images.map((image, index) => {
+                  return (
+                    <div key={index} className="w-full mb-[10px]">
+                      <Image
+                        src={image}
+                        alt={`과제상세이미지${index}`}
+                        width="0"
+                        height="0"
+                        sizes="100vw"
+                        style={{ width: "auto", height: "auto" }}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/src/app/assignment/[assignmentId]/page.tsx
+++ b/src/app/assignment/[assignmentId]/page.tsx
@@ -8,13 +8,6 @@ import { useSelector } from "react-redux";
 import useUserInfo from "@/hooks/user/useUserInfo";
 import { RootState } from "@/redux/store";
 
-// const user: User = {
-//   id: "id",
-//   role: "관리자", // 관리자, 수강생
-//   username: "김지은",
-//   profileImage: "user.png",
-// };
-
 const AssignmentDetailPage = () => {
   // FIXME: 임시 유저 정보 처리
   const userId = useSelector((state: RootState) => {

--- a/src/utils/emptyArrayCheck.ts
+++ b/src/utils/emptyArrayCheck.ts
@@ -1,0 +1,10 @@
+const emptyArrayCheck = (array: any) => {
+  for (const value of array) {
+    if (value === "") {
+      // 빈 문자열을 발견한 경우
+      return true;
+    }
+  }
+};
+
+export default emptyArrayCheck;

--- a/src/utils/timestampToIntlDate.ts
+++ b/src/utils/timestampToIntlDate.ts
@@ -1,0 +1,24 @@
+import type { Timestamp } from "firebase/firestore";
+
+// timestamp: fs timestamp, separator: 날짜 구분자 인자로 전달(ex) '/', '.', '-' 등)
+const timestampToIntlDate = (
+  timestamp: Timestamp,
+  separator: string,
+): string => {
+  const date = new Date(timestamp.seconds * 1000); // fs timestamp를 JavaScript Date로 변환
+
+  const options: Intl.DateTimeFormatOptions = {
+    // Intl 옵션
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  };
+  const formattedDate = new Intl.DateTimeFormat("ko-KR", options).format(date);
+  // 정규식을 통한 separator 설정 및 공백 제거
+  return formattedDate
+    .replace(/\.$/, "")
+    .replace(/\./g, separator)
+    .replace(/ /g, "");
+};
+
+export default timestampToIntlDate;


### PR DESCRIPTION
## 개요 :mag:

- deprecated 된 moment.js나 day.js 같은 라이브러리 대신 Intl API를 활용한 날짜 포맷팅 진행 
- 과제 상세 이미지 url 바인딩

## 작업사항 :memo:

- Intl API를 활용해서 포맷팅
- 공통 컴포넌트로 사용하기 위해 인자로 separator 전달 가능하게 작업
- 과제 생성 시 등록한 이미지 url 바인딩
-  firebase 컬렉션 구조상 value가 없는 경우 빈 문자열의 배열이 들어가는 경우가 많아서 `emptyArrayCheck` 추가 -> 추후 불필요할 시 삭제

close #279 #286 

## 테스트 방법(optional)

첫 번째 인자로 timestamp value, 두 번째 인자로 separator 전달
ex) `timestampToIntlDate(assignment.createdAt, "/")`
