### PR TITLE
Fix: 댓글/답글 수정 시, 콘솔 경고 수정

### DIFF
--- a/src/app/classroom/(components)/modal/comment/EditComment.tsx
+++ b/src/app/classroom/(components)/modal/comment/EditComment.tsx
@@ -26,7 +26,13 @@ const EditComment: React.FC<EditCommentProps> = ({
       <div className="flex flex-col w-full">
         <UserInfo username={username} role={role} />
         <div className="w-full flex justify-between items-start">
-          <form className="w-full flex flex-col">
+          <form
+            className="w-full flex flex-col"
+            onSubmit={event => {
+              event.preventDefault();
+              onEdit(textareaValue);
+            }}
+          >
             <textarea
               value={textareaValue}
               onChange={e => setTextareaValue(e.target.value)}
@@ -34,14 +40,15 @@ const EditComment: React.FC<EditCommentProps> = ({
             />
             <div className="flex justify-end space-x-4 mt-2">
               <button
+                type="button"
                 className="w-28 h-8 text-sm rounded-lg bg-gray-100 text-gray-500"
                 onClick={onCancel}
               >
                 취소하기
               </button>
               <button
+                type="submit"
                 className="w-28 h-8 text-sm rounded-lg bg-blue-500 text-white hover:bg-white hover:border hover:border-blue-600 hover:text-blue-600"
-                onClick={() => onEdit(textareaValue)}
               >
                 수정하기
               </button>


### PR DESCRIPTION
## 개요 :mag:

댓글/답글을 수정할 때, 기능을 제대로 이루어지지만 폼에 대한 경고가 콘솔에 나왔는데,
원인은 prevent를 설정하지 않았기 때문.
그래서 이를 추가함.

## 작업사항 :memo:


## 테스트 방법(optional)


