### PR TITLE
Feat: 과제 파일 제출 기능 외 기존 custom hook 수정

### DIFF
--- a/src/app/assignment/(components)/AssignmentTeacherViewCard.tsx
+++ b/src/app/assignment/(components)/AssignmentTeacherViewCard.tsx
@@ -75,7 +75,7 @@ const AssignmentTeacherViewCard: React.FC<IAssignmentTeacherViewCardProps> = ({
           </div>
           <div className="flex flex-col justify-between items-end">
             <div className="w-[19px] h-[19px]">
-              {submittedItem.isRead ? (
+              {!submittedItem.isRead ? (
                 <div className="w-full h-full">
                   <Image
                     src="/images/icon_new.svg"

--- a/src/hooks/mutation/useSubmitAssignment.ts
+++ b/src/hooks/mutation/useSubmitAssignment.ts
@@ -10,7 +10,7 @@ import { db } from "@utils/firebase";
 
 const submitAssignment = async (
   assignmentId: string,
-  attachmentValue: string[],
+  attachmentValue: (string | { name: string; url: string })[],
   userId: string,
 ): Promise<DocumentReference> => {
   const userRef = doc(db, "users", userId);
@@ -33,12 +33,21 @@ const submitAssignment = async (
       },
     );
 
-    await addDoc(collection(db, "attachments"), {
-      links: [...attachmentValue],
-      submittedAssignmentId: addSubmittedAssignmentData,
-      // createdAt: createdAtTimeStamp,
-      userId: userRef,
-    });
+    if (typeof attachmentValue[0] === "string") {
+      await addDoc(collection(db, "attachments"), {
+        attachmentFiles: [{ name: "", url: "" }],
+        links: [...attachmentValue],
+        submittedAssignmentId: addSubmittedAssignmentData,
+        userId: userRef,
+      });
+    } else {
+      await addDoc(collection(db, "attachments"), {
+        attachmentFiles: [...attachmentValue],
+        links: [""],
+        submittedAssignmentId: addSubmittedAssignmentData,
+        userId: userRef,
+      });
+    }
 
     return addSubmittedAssignmentData;
   } catch (err) {
@@ -50,7 +59,7 @@ const submitAssignment = async (
 const useSubmitAssignment = (assignmentId: string, userId: string) => {
   const queryClient = useQueryClient();
   const { mutate, isLoading, error } = useMutation(
-    (attachmentValue: string[]) =>
+    (attachmentValue: (string | { name: string; url: string })[]) =>
       submitAssignment(assignmentId, attachmentValue, userId),
     {
       onSuccess: () => {

--- a/src/hooks/mutation/useUpdateFiles.ts
+++ b/src/hooks/mutation/useUpdateFiles.ts
@@ -1,0 +1,16 @@
+import { useMutation } from "@tanstack/react-query";
+import { storage } from "@utils/firebase";
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
+
+const useFilesUpload = () => {
+  const uploadFiles = async (file: File) => {
+    const storageRef = ref(storage, `attachments/${file.name}`);
+    await uploadBytes(storageRef, file);
+    const url = await getDownloadURL(storageRef);
+    return url;
+  };
+
+  return useMutation(uploadFiles);
+};
+
+export default useFilesUpload;

--- a/src/hooks/queries/useGetSubmittedAssignment.ts
+++ b/src/hooks/queries/useGetSubmittedAssignment.ts
@@ -7,10 +7,11 @@ import {
   query,
   where,
   DocumentData,
+  Timestamp,
 } from "firebase/firestore";
 
 import { db } from "@utils/firebase";
-import { SubmittedAssignment, Attachment, User } from "@/types/firebase.types";
+import { Attachment, SubmittedAssignment, User } from "@/types/firebase.types";
 
 const getSubmittedAssignments = async (
   assignmentId: string,
@@ -64,14 +65,8 @@ const getSubmittedAssignments = async (
   );
   const submittedAssignmentsDocs = await getDocs(submittedAssignmentsQuery);
 
-  // createdAt 시간순으로 sort
-  const sortSubmittedAssignments = submittedAssignmentsDocs?.docs.sort(
-    (a: DocumentData, b: DocumentData) =>
-      a.date().createdAt.seconds - b.date().createdAt.seconds,
-  );
-
-  const submittedAssignments = await Promise.all(
-    sortSubmittedAssignments.map(async document => {
+  const rawSubmittedAssignments = await Promise.all(
+    submittedAssignmentsDocs?.docs.map(async document => {
       const attachmentQuery = query(
         collection(db, "attachments"),
         where("submittedAssignmentId", "==", document.ref),
@@ -89,6 +84,11 @@ const getSubmittedAssignments = async (
         ...document.data(),
       };
     }),
+  );
+
+  const submittedAssignments = rawSubmittedAssignments.sort(
+    (a: DocumentData, b: DocumentData) =>
+      a.createdAt.seconds - b.createdAt.seconds,
   );
 
   return submittedAssignments;


### PR DESCRIPTION
## 개요 :mag:

- 과제 파일 제출 기능


## 작업사항 :memo:

- dropzone을 통한 과제 파일 제출 기능 작업
- 기존 custom hook 해당 기능에 맞게 수정
- 사용자 패턴에 따른 토스트ui 분기처리 추가 및 중복파일 필터 필요


## 테스트 방법(optional)

학생 계정으로 접속해서 과제 파일로 제출 진행