### PR TITLE
Update: 과제 sidebar Dnd on/off, reset, update, delete 기능 추가

### DIFF
--- a/src/app/assignment/(components)/AssignmentLeftNav.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNav.tsx
@@ -1,11 +1,11 @@
 "use client";
+import { useSelector } from "react-redux";
 import Image from "next/image";
 import Link from "next/link";
-import AssignmentLeftNavContent from "./AssignmentLeftNavContent";
-import { useSelector } from "react-redux";
-import { RootState } from "@/redux/store";
 import useUserInfo from "@/hooks/user/useUserInfo";
+import { RootState } from "@/redux/store";
 import { User } from "@/types/firebase.types";
+import AssignmentLeftNavContent from "./AssignmentLeftNavContent";
 
 const AssignmentLeftNav = () => {
   const userId = useSelector((state: RootState) => {

--- a/src/app/assignment/(components)/AssignmentLeftNavContent.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContent.tsx
@@ -41,14 +41,13 @@ const AssignmentLeftNavContent = (prop: Props) => {
   const editingCount = useRef(0);
 
   const alignAssignmentData = (htmlContent: AssignmentExtracted[]) => {
-    
     const assignSorted = htmlContent?.toSorted(
       (a: AssignmentExtracted, b: AssignmentExtracted) => a.index - b.index,
-      );
+    );
     setHcAligned(assignSorted);
   };
 
-  const fetchAssignmentData = (assignQueriesdata) => {
+  const fetchAssignmentData = assignQueriesdata => {
     let htmlcontent = [];
     let initialhtml = [];
     const assignFetched = assignQueriesdata;
@@ -56,28 +55,28 @@ const AssignmentLeftNavContent = (prop: Props) => {
 
     //order 순서대로 데이터 불러오기 및 추출(이후에는 moveCard로 순서보존)
     for (let i = 0; i < len; i++) {
-        const assignCopied = assignFetched[i];
-        let assignExtracted = {
-          id: assignCopied.id,
-          index: i,
-          order: assignCopied.order,
-          title: assignCopied.title,
-        };
-        let initialAssign = {
-          id: assignCopied.id,
-          index: i,
-          order: assignCopied.order,
-          title: assignCopied.title,
-        }
-        htmlcontent.push(assignExtracted);
-        initialhtml.push(initialAssign);
+      const assignCopied = assignFetched[i];
+      let assignExtracted = {
+        id: assignCopied.id,
+        index: i,
+        order: assignCopied.order,
+        title: assignCopied.title,
+      };
+      let initialAssign = {
+        id: assignCopied.id,
+        index: i,
+        order: assignCopied.order,
+        title: assignCopied.title,
+      };
+      htmlcontent.push(assignExtracted);
+      initialhtml.push(initialAssign);
     }
     console.log(
-      "[AssignmentLeftNavContent_FUNC] FetchAssignmentData 데이터 로드 완료!"
+      "[AssignmentLeftNavContent_FUNC] FetchAssignmentData 데이터 로드 완료!",
     );
-    initialHtml.current = [...initialhtml]
+    initialHtml.current = [...initialhtml];
     setHtmlcontent(htmlcontent);
-  }
+  };
 
   useEffect(() => {
     //초기 데이터 fetch 및 추출
@@ -95,7 +94,7 @@ const AssignmentLeftNavContent = (prop: Props) => {
   /* #region  */
   //. 과제 변경 모듈
   //index 서로 바꾸고 컴포넌트 리로드
-  const moveCard = (dragIndex:Number, hoverIndex:Number) => {
+  const moveCard = (dragIndex: Number, hoverIndex: Number) => {
     editingCount.current += 1;
     setHtmlcontent((prev: AssignmentExtracted) => {
       let hcSpliced = prev.toSpliced(dragIndex, 1, prev[hoverIndex]); //dragIndex에 hoverIndex 자리의 값이 들어감
@@ -108,14 +107,13 @@ const AssignmentLeftNavContent = (prop: Props) => {
     });
   };
 
-
   const UpdateAssignmentOrder = () => {
-    if (!assignOrderMutation.isLoading && editingCount.current!==0) {
-      console.log("실행!")
-      editingCount.current=0;
+    if (!assignOrderMutation.isLoading && editingCount.current !== 0) {
+      console.log("실행!");
+      editingCount.current = 0;
       assignOrderMutation.mutate(htmlContentAligned);
     }
-    setIseiditing(false)
+    setIseiditing(false);
   };
 
   const resetEditting = () => {
@@ -132,22 +130,22 @@ const AssignmentLeftNavContent = (prop: Props) => {
     const formElem = event.target;
     let formData = new FormData();
     for (let k = 0; k < formElem.length; k++) {
-      if(formElem[k].checked){
+      if (formElem[k].checked) {
         const deleteTargetName = formElem[k].name;
         const deleteTargetValue = formElem[k].value;
         formData.set(deleteTargetName, deleteTargetValue);
       }
     }
     let deletingAssignmentId = [];
-    if(!(formData.keys().length===0)){
+    if (!(formData.keys().length === 0)) {
       for (const key of formData.keys()) {
-          deletingAssignmentId.push(key)
-        };
-      assignDeletingMutation.mutate(deletingAssignmentId);
+        deletingAssignmentId.push(key);
       }
-      editingCount.current=0
-      setIseiditing(false);
-    };
+      assignDeletingMutation.mutate(deletingAssignmentId);
+    }
+    editingCount.current = 0;
+    setIseiditing(false);
+  };
   /* #endregion */
 
   return (

--- a/src/app/assignment/(components)/AssignmentLeftNavContent.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContent.tsx
@@ -39,7 +39,7 @@ const AssignmentLeftNavContent = (props: Props) => {
     setHcAligned(assignSorted);
   };
 
-  const fetchAssignmentData = (assignQueriesdata:Assignment[]) => {
+  const fetchAssignmentData = (assignQueriesdata: Assignment[]) => {
     let htmlcontent = [];
     let initialhtml = [];
     const assignFetched = assignQueriesdata;
@@ -82,7 +82,7 @@ const AssignmentLeftNavContent = (props: Props) => {
   //index 서로 바꾸고 컴포넌트 리로드
   const moveCard = (dragIndex: number, hoverIndex: number) => {
     editingCount.current += 1;
-    setHtmlcontent((prev) => {
+    setHtmlcontent(prev => {
       let hcSpliced = prev.toSpliced(dragIndex, 1, prev[hoverIndex]); //dragIndex에 hoverIndex 자리의 값이 들어감
       let hcDoubleSpliced = hcSpliced.toSpliced(hoverIndex, 1, prev[dragIndex]);
       hcDoubleSpliced[dragIndex].order = prev[dragIndex].order;
@@ -105,13 +105,13 @@ const AssignmentLeftNavContent = (props: Props) => {
     setHtmlcontent(initialHtml.current);
     setIsEditting(false);
   };
-  
+
   const StartEditting = () => {
     setIsEditting(true);
   };
 
-  const deleteAssignmentElems = (event) => {
-    console.log(event)
+  const deleteAssignmentElems = event => {
+    console.log(event);
     event.preventDefault();
     const formElem = event.target;
     let formData = new FormData();

--- a/src/app/assignment/(components)/AssignmentLeftNavContentButton.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContentButton.tsx
@@ -2,24 +2,25 @@
 
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
+import { User } from "@/types/firebase.types";
 import AssignmentCreate from "./AssignmentCreate";
 import AssignmentModal from "./AssignmentModal";
-import { Props } from "./AssignmentLeftNavContent";
 
-interface Props2 extends Props {
+interface Props {
+  userInfo:User;
   UpdateAssignmentOrder: () => void;
   ResetEditting: () => void;
+  modeChanger: () => void;
 }
 
-const AssignmentLeftNavButton = (prop: Props2) => {
+const AssignmentLeftNavButton = (props: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isActivated, setIsActivated] = useState<boolean>(false);
-  console.log("[AssignmentLeftNavButton] 실행!");
 
-  const handleKeyPress = event => {
+  const handleKeyPress = (event) => {
     if (event.keyCode === 27) {
       setIsActivated(false);
-      prop.ResetEditting();
+      props.ResetEditting();
     }
   };
 
@@ -36,17 +37,17 @@ const AssignmentLeftNavButton = (prop: Props2) => {
   }, [isActivated]);
 
   const executeEditing = () => {
-    prop.modeChanger();
+    props.modeChanger();
     setIsActivated(true);
   };
 
   const updateAndDeactivate = () => {
-    prop.UpdateAssignmentOrder();
+    props.UpdateAssignmentOrder();
     setIsActivated(false);
   };
   return (
     <div>
-      {prop.userInfo.role === "관리자" ? (
+      {props.userInfo.role === "관리자" ? (
         <div className="w-full">
           <div className="flex justify-center items-center w-full h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
             <button
@@ -83,8 +84,6 @@ const AssignmentLeftNavButton = (prop: Props2) => {
                 onClick={() => {
                   updateAndDeactivate();
                 }}
-                form="assign"
-                name="assign"
                 className="w-[115px] h-[35px] p-[9px] rounded-lg flex bg-[#337AFF] text-slate-50"
               >
                 <span className="m-auto">적용</span>

--- a/src/app/assignment/(components)/AssignmentLeftNavContentButton.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContentButton.tsx
@@ -7,7 +7,7 @@ import AssignmentCreate from "./AssignmentCreate";
 import AssignmentModal from "./AssignmentModal";
 
 interface Props {
-  userInfo:User;
+  userInfo: User;
   UpdateAssignmentOrder: () => void;
   ResetEditting: () => void;
   modeChanger: () => void;
@@ -17,7 +17,7 @@ const AssignmentLeftNavButton = (props: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isActivated, setIsActivated] = useState<boolean>(false);
 
-  const handleKeyPress = (event) => {
+  const handleKeyPress = event => {
     if (event.keyCode === 27) {
       setIsActivated(false);
       props.ResetEditting();

--- a/src/app/assignment/(components)/AssignmentLeftNavContentButton.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContentButton.tsx
@@ -6,15 +6,47 @@ import AssignmentCreate from "./AssignmentCreate";
 import AssignmentModal from "./AssignmentModal";
 import { Props } from "./AssignmentLeftNavContent";
 
-const AssignmentLeftNavButton = (prop: Props) => {
+interface Props2 extends Props{
+  UpdateAssignmentOrder: ()=>void;
+  ResetEditting : ()=>void;
+}
+
+const AssignmentLeftNavButton = (prop: Props2) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [isActivated, setIsActivated] = useState<boolean>(false);
   console.log("[AssignmentLeftNavButton] 실행!");
 
-  const executeEditing = () => {
-    setIsActivated(true);
-    prop.modeChanger();
+
+  const handleKeyPress = (event) => {
+    if (event.keyCode === 27) {
+      setIsActivated(false)
+      prop.ResetEditting();
+    }
   };
+
+  useEffect(()=>{
+    if (isActivated===true){
+      window.addEventListener('keydown', handleKeyPress);
+    }
+    else{
+      window.removeEventListener('keydown', handleKeyPress);
+    }
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress);
+    };
+  },[isActivated])
+
+
+  const executeEditing = () => {
+    prop.modeChanger();
+    setIsActivated(true);
+  };
+
+  const updateAndDeactivate = () => {
+    prop.UpdateAssignmentOrder()
+    setIsActivated(false);
+  }
   return (
     <div>
       {prop.userInfo.role === "관리자" ? (
@@ -50,7 +82,8 @@ const AssignmentLeftNavButton = (prop: Props) => {
           {isActivated ? (
             <div className="flex justify-center items-center w-full h-[46px] mx-0 my-[10px] gap-[6px] flex-shrink-0 bg-white rounded-[10px] ">
               <button
-                type="submit"
+                type="button"
+                onClick={()=>{updateAndDeactivate()}}
                 form="assign"
                 name="assign"
                 className="w-[115px] h-[35px] p-[9px] rounded-lg flex bg-[#337AFF] text-slate-50"
@@ -59,6 +92,7 @@ const AssignmentLeftNavButton = (prop: Props) => {
               </button>
               <button
                 type="submit"
+                onClick={()=>{setTimeout(()=>{setIsActivated(false),1000})}}
                 form="assign"
                 name="assign"
                 className="w-[115px] h-[35px] p-[9px] rounded-lg flex bg-[#FF0000] text-slate-50 "
@@ -68,24 +102,9 @@ const AssignmentLeftNavButton = (prop: Props) => {
             </div>
           ) : (
             <div className="flex justify-center items-center w-full h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
-              <form
-                onSubmit={() => {
-                  executeEditing();
-                }}
-                id="type"
-                name="type"
-              >
-                <input
-                  type="checkbox"
-                  name="type"
-                  value="EDIT"
-                  className="hidden"
-                ></input>
-              </form>
               <button
-                type="submit"
-                form="type"
-                name="type"
+                type="button"
+                onClick={()=>{executeEditing()}}
                 className="flex justify-center items-center gap-[6px]"
               >
                 <Image

--- a/src/app/assignment/(components)/AssignmentLeftNavContentButton.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContentButton.tsx
@@ -6,9 +6,9 @@ import AssignmentCreate from "./AssignmentCreate";
 import AssignmentModal from "./AssignmentModal";
 import { Props } from "./AssignmentLeftNavContent";
 
-interface Props2 extends Props{
-  UpdateAssignmentOrder: ()=>void;
-  ResetEditting : ()=>void;
+interface Props2 extends Props {
+  UpdateAssignmentOrder: () => void;
+  ResetEditting: () => void;
 }
 
 const AssignmentLeftNavButton = (prop: Props2) => {
@@ -16,27 +16,24 @@ const AssignmentLeftNavButton = (prop: Props2) => {
   const [isActivated, setIsActivated] = useState<boolean>(false);
   console.log("[AssignmentLeftNavButton] 실행!");
 
-
-  const handleKeyPress = (event) => {
+  const handleKeyPress = event => {
     if (event.keyCode === 27) {
-      setIsActivated(false)
+      setIsActivated(false);
       prop.ResetEditting();
     }
   };
 
-  useEffect(()=>{
-    if (isActivated===true){
-      window.addEventListener('keydown', handleKeyPress);
-    }
-    else{
-      window.removeEventListener('keydown', handleKeyPress);
+  useEffect(() => {
+    if (isActivated === true) {
+      window.addEventListener("keydown", handleKeyPress);
+    } else {
+      window.removeEventListener("keydown", handleKeyPress);
     }
 
     return () => {
-      window.removeEventListener('keydown', handleKeyPress);
+      window.removeEventListener("keydown", handleKeyPress);
     };
-  },[isActivated])
-
+  }, [isActivated]);
 
   const executeEditing = () => {
     prop.modeChanger();
@@ -44,9 +41,9 @@ const AssignmentLeftNavButton = (prop: Props2) => {
   };
 
   const updateAndDeactivate = () => {
-    prop.UpdateAssignmentOrder()
+    prop.UpdateAssignmentOrder();
     setIsActivated(false);
-  }
+  };
   return (
     <div>
       {prop.userInfo.role === "관리자" ? (
@@ -83,7 +80,9 @@ const AssignmentLeftNavButton = (prop: Props2) => {
             <div className="flex justify-center items-center w-full h-[46px] mx-0 my-[10px] gap-[6px] flex-shrink-0 bg-white rounded-[10px] ">
               <button
                 type="button"
-                onClick={()=>{updateAndDeactivate()}}
+                onClick={() => {
+                  updateAndDeactivate();
+                }}
                 form="assign"
                 name="assign"
                 className="w-[115px] h-[35px] p-[9px] rounded-lg flex bg-[#337AFF] text-slate-50"
@@ -92,7 +91,11 @@ const AssignmentLeftNavButton = (prop: Props2) => {
               </button>
               <button
                 type="submit"
-                onClick={()=>{setTimeout(()=>{setIsActivated(false),1000})}}
+                onClick={() => {
+                  setTimeout(() => {
+                    setIsActivated(false), 1000;
+                  });
+                }}
                 form="assign"
                 name="assign"
                 className="w-[115px] h-[35px] p-[9px] rounded-lg flex bg-[#FF0000] text-slate-50 "
@@ -104,7 +107,9 @@ const AssignmentLeftNavButton = (prop: Props2) => {
             <div className="flex justify-center items-center w-full h-[46px] mt-[10px] gap-[6px] flex-shrink-0 border border-primary-40 bg-white rounded-[10px]">
               <button
                 type="button"
-                onClick={()=>{executeEditing()}}
+                onClick={() => {
+                  executeEditing();
+                }}
                 className="flex justify-center items-center gap-[6px]"
               >
                 <Image

--- a/src/app/assignment/(components)/AssignmentLeftNavContentCard.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContentCard.tsx
@@ -4,12 +4,12 @@ import { useDrag, useDrop } from "react-dnd";
 import { useRef } from "react";
 import { AssignmentExtracted } from "./AssignmentLeftNavContent";
 
-interface Props extends AssignmentExtracted{
+interface Props extends AssignmentExtracted {
   movecard: (dragIndex: number, hoverIndex: number) => void;
   isEditting: boolean;
 }
 
-const AssignmentLeftNavCard = (props:Props) => {
+const AssignmentLeftNavCard = (props: Props) => {
   const ref = useRef<HTMLDivElement>(null);
   const { id, title, movecard, index, isEditting } = props;
 
@@ -40,7 +40,7 @@ const AssignmentLeftNavCard = (props:Props) => {
       item.index = hoverIndex;
     },
   }));
-  
+
   const opacity = isDragging ? 0 : 100;
   drag(drop(ref));
 

--- a/src/app/assignment/(components)/AssignmentLeftNavContentCard.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContentCard.tsx
@@ -4,9 +4,15 @@ import { useDrag, useDrop } from "react-dnd";
 import { useRef } from "react";
 import { AssignmentExtracted } from "./AssignmentLeftNavContent";
 
-const AssignmentLeftNavCard = (props: AssignmentExtracted) => {
+interface Props extends AssignmentExtracted{
+  movecard: (dragIndex: number, hoverIndex: number) => void;
+  isEditting: boolean;
+}
+
+const AssignmentLeftNavCard = (props:Props) => {
   const ref = useRef<HTMLDivElement>(null);
-  const { id, order, title, movecard, index, isEditing } = props;
+  const { id, title, movecard, index, isEditting } = props;
+
   const [{ isDragging }, drag] = useDrag(() => ({
     type: "card",
     item: () => {
@@ -28,20 +34,19 @@ const AssignmentLeftNavCard = (props: AssignmentExtracted) => {
 
       // Don't replace items with themselves
       if (dragIndex === hoverIndex) {
-        console.log("똑같!");
         return;
       }
       movecard(dragIndex, hoverIndex);
       item.index = hoverIndex;
-      console.log("dragIndex:", dragIndex, "hoverIndex", hoverIndex);
     },
   }));
+  
   const opacity = isDragging ? 0 : 100;
   drag(drop(ref));
 
   return (
     <div>
-      {isEditing ? (
+      {isEditting ? (
         <div
           ref={ref}
           key={id}

--- a/src/app/assignment/(components)/AssignmentLeftNavContentCard.tsx
+++ b/src/app/assignment/(components)/AssignmentLeftNavContentCard.tsx
@@ -45,15 +45,15 @@ const AssignmentLeftNavCard = (props: AssignmentExtracted) => {
         <div
           ref={ref}
           key={id}
-          className={`list-none w-full p-[10px] order-${id} opacity-${opacity}`}
+          className={`list-none w-full p-[10px] order-${index} opacity-${opacity}`}
         >
-          <input type="checkbox" name={id} />
+          <input type="checkbox" name={id} value={index} />
           <Link href={"/assignment/" + id}>{title}</Link>
         </div>
       ) : (
         <div
           key={id}
-          className={`list-none w-full p-[10px] order-${id} opacity-${opacity}`}
+          className={`list-none w-full p-[10px] order-${index} opacity-${opacity}`}
         >
           <Link href={"/assignment/" + id}>{title}</Link>
         </div>

--- a/src/app/assignment/(components)/AssignmentListContent.tsx
+++ b/src/app/assignment/(components)/AssignmentListContent.tsx
@@ -13,7 +13,7 @@ interface AssignmentNumberAdded extends Assignment {
 
 type Props = {
   userInfo: User;
-  userId : string;
+  userId: string;
 };
 
 const AssignmentListContent = (prop: Props) => {

--- a/src/app/assignment/(components)/AssignmentListContent.tsx
+++ b/src/app/assignment/(components)/AssignmentListContent.tsx
@@ -13,7 +13,9 @@ interface AssignmentNumberAdded extends Assignment {
 
 type Props = {
   userInfo: User;
+  userId : string;
 };
+
 const AssignmentListContent = (prop: Props) => {
   const assignmentData = useGetAssignment("");
   const router = useRouter();
@@ -36,7 +38,7 @@ const AssignmentListContent = (prop: Props) => {
             {assign.title}
           </span>
         </div>
-        {userinfo.role === "관리자" ? (
+        {userinfo?.role === "관리자" ? (
           <button
             type="button"
             onClick={() => {
@@ -47,7 +49,7 @@ const AssignmentListContent = (prop: Props) => {
             확인하기
           </button>
         ) : (
-          <AssignmentListSubButton targetId={assign.id} userInfo={userinfo} />
+          <AssignmentListSubButton refId={assign.id} userId={prop.userId} />
         )}
       </div>
     ));

--- a/src/app/assignment/(components)/AssignmentListSubButton.tsx
+++ b/src/app/assignment/(components)/AssignmentListSubButton.tsx
@@ -1,32 +1,33 @@
 "use client";
 
-import React from "react";
-import Link from "next/link";
+import React, {useEffect, useState} from "react";
 import { useGetSubmittedAssignments } from "@hooks/queries/useGetSubmittedAssignment";
 import { useRouter } from "next/navigation";
-import { User } from "@/types/firebase.types";
 
 interface Props {
-  targetId: string;
-  userInfo: User;
+  refId: string;
+  userId: string;
 }
 
 //추후 userinfo도 넣어야함
-const AssignmentListSubButton = ({ targetId, userInfo }: Props) => {
-  const submittionHooks = useGetSubmittedAssignments(targetId);
+const AssignmentListSubButton = ({ refId, userId }: Props) => {
+  const submittionHooks = useGetSubmittedAssignments(refId, userId);
+  const isLoading = submittionHooks.isLoading
   const router = useRouter();
-  let isSubmitted;
+  const [isSubmitted, setIsSubmitted] = useState(false);
 
-  if (!submittionHooks.isLoading) {
-    isSubmitted = submittionHooks.data?.length > 0;
-  }
+  useEffect(()=>{
+      if (!isLoading) {
+        const issubmitted = (submittionHooks.data?.length >0)
+        setIsSubmitted(issubmitted);
+      }},[isLoading, submittionHooks.data])
 
   return (
     <div>
       {isSubmitted ? (
         <button
           onClick={() => {
-            router.push("/assignment/" + targetId);
+            router.push("/assignment/" + refId);
           }}
           type="button"
           className="w-[157px] h-[35px] p-[9px] gap-[10px] flex justify-center items-center flex-shrink-0 rounded-[10px] bg-zinc-100 font-bold text-zinc-500	border-none"
@@ -36,7 +37,7 @@ const AssignmentListSubButton = ({ targetId, userInfo }: Props) => {
       ) : (
         <button
           onClick={() => {
-            router.push("/assignment/" + targetId);
+            router.push("/assignment/" + refId);
           }}
           type="button"
           className="w-[157px] h-[35px] p-[9px] gap-[10px] flex justify-center items-center flex-shrink-0 rounded-[10px] bg-primary-80 font-bold text-slate-50 border-none"

--- a/src/app/assignment/(components)/AssignmentListSubButton.tsx
+++ b/src/app/assignment/(components)/AssignmentListSubButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import { useGetSubmittedAssignments } from "@hooks/queries/useGetSubmittedAssignment";
 import { useRouter } from "next/navigation";
 
@@ -12,15 +12,16 @@ interface Props {
 //추후 userinfo도 넣어야함
 const AssignmentListSubButton = ({ refId, userId }: Props) => {
   const submittionHooks = useGetSubmittedAssignments(refId, userId);
-  const isLoading = submittionHooks.isLoading
+  const isLoading = submittionHooks.isLoading;
   const router = useRouter();
   const [isSubmitted, setIsSubmitted] = useState(false);
 
-  useEffect(()=>{
-      if (!isLoading) {
-        const issubmitted = (submittionHooks.data?.length >0)
-        setIsSubmitted(issubmitted);
-      }},[isLoading, submittionHooks.data])
+  useEffect(() => {
+    if (!isLoading) {
+      const issubmitted = submittionHooks.data?.length > 0;
+      setIsSubmitted(issubmitted);
+    }
+  }, [isLoading, submittionHooks.data]);
 
   return (
     <div>

--- a/src/app/assignment/page.tsx
+++ b/src/app/assignment/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import React from "react";
-import AssignmentListContent from "./(components)/AssignmentListContent";
 import { useSelector } from "react-redux";
 import useUserInfo from "@/hooks/user/useUserInfo";
 import { RootState } from "@/redux/store";
 import { User } from "@/types/firebase.types";
+import AssignmentListContent from "./(components)/AssignmentListContent";
 
 const Assignment = () => {
   const userId = useSelector((state: RootState) => {
@@ -17,7 +17,7 @@ const Assignment = () => {
 
   return (
     <div>
-      <AssignmentListContent userInfo={userInfo} />
+      <AssignmentListContent userInfo={userInfo} userId={userId.uid} />
     </div>
   );
 };

--- a/src/hooks/mutation/useDeleteRegisteredAssignmentByAssignmentId.ts
+++ b/src/hooks/mutation/useDeleteRegisteredAssignmentByAssignmentId.ts
@@ -2,22 +2,23 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { doc, deleteDoc, writeBatch } from "firebase/firestore";
 import { db } from "@utils/firebase";
 
-const deleteRegisteredAssignment = async (deletingAssignmentIndex:string[]) => {
+const deleteRegisteredAssignment = async (
+  deletingAssignmentIndex: string[],
+) => {
   try {
-    if (deletingAssignmentIndex.length===0){
-      throw (Error);
+    if (deletingAssignmentIndex.length === 0) {
+      throw Error;
     }
     // Get a new write batch
     const batch = writeBatch(db);
 
-    deletingAssignmentIndex.forEach((targetIndex:string)=>{
-      const deleteRef = doc(db, "assignments", targetIndex)
+    deletingAssignmentIndex.forEach((targetIndex: string) => {
+      const deleteRef = doc(db, "assignments", targetIndex);
       batch.delete(deleteRef);
-    })
+    });
 
     // Commit the batch
     await batch.commit();
-
   } catch (err) {
     console.log(err);
     throw err;
@@ -27,7 +28,8 @@ const deleteRegisteredAssignment = async (deletingAssignmentIndex:string[]) => {
 const useDeleteRegisteredAssignmentByAssignmentId = () => {
   const queryClient = useQueryClient();
   const { mutate, isLoading, error } = useMutation(
-    (deletingAssignmentIndex:string[]) => deleteRegisteredAssignment(deletingAssignmentIndex),
+    (deletingAssignmentIndex: string[]) =>
+      deleteRegisteredAssignment(deletingAssignmentIndex),
     {
       onSuccess: () => {
         queryClient.invalidateQueries(["getAssignment", ""]);

--- a/src/hooks/mutation/useUpdateAssignmentOrder.ts
+++ b/src/hooks/mutation/useUpdateAssignmentOrder.ts
@@ -1,22 +1,26 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { updateDoc, writeBatch, doc, DocumentReference } from "firebase/firestore";
+import {
+  updateDoc,
+  writeBatch,
+  doc,
+  DocumentReference,
+} from "firebase/firestore";
 import { db } from "@utils/firebase";
 import { AssignmentExtracted } from "@/app/assignment/(components)/AssignmentLeftNavContent";
 
 // Firestore 데이터 추가
-const updateAssignment = async (assignmentValue:AssignmentExtracted[]) => {
+const updateAssignment = async (assignmentValue: AssignmentExtracted[]) => {
   try {
     // Get a new write batch
     const batch = writeBatch(db);
 
-    assignmentValue.forEach((assign:AssignmentExtracted)=>{
-      const updateRef = doc(db, "assignments", assign.id)
-      batch.update(updateRef, {"order": assign.index});
-    })
+    assignmentValue.forEach((assign: AssignmentExtracted) => {
+      const updateRef = doc(db, "assignments", assign.id);
+      batch.update(updateRef, { order: assign.index });
+    });
 
     // Commit the batch
     await batch.commit();
-
   } catch (err) {
     console.log(err);
     throw err;


### PR DESCRIPTION
## 개요 :mag:

과제 sidebar Dnd on/off, reset, update, delete 기능 추가

## 작업사항 :memo:
`close #37 `

## 테스트 방법(optional)
- sidebar에서 순서변경 버튼을 누른 뒤, `esc` 버튼을 누르면 수정취소를 실행할 수 있습니다.
- 아직 사용자별 제출여부에 따른 분기처리는 완료되지 않았습니다.

