### PR TITLE
Feat : 클래스룸에서 강의 수정 기능 구현

### DIFF
--- a/src/app/classroom/(components)/main/ContentInfo.tsx
+++ b/src/app/classroom/(components)/main/ContentInfo.tsx
@@ -1,6 +1,9 @@
 import timestampToDate from "@/utils/timestampToDate";
 import { convertSecondsToMinute } from "@/utils/convertSecondsToMinute";
-import { setModalVisibility } from "@/redux/slice/classroomModalSlice";
+import {
+  setLecture,
+  setModalVisibility,
+} from "@/redux/slice/classroomModalSlice";
 import { useRouter } from "next/navigation";
 import { useDispatch } from "react-redux";
 import { ILecture } from "@/hooks/queries/useGetCourseList";
@@ -53,6 +56,7 @@ const ContentInfo = ({ lecture, setDeleteModal }: IProps) => {
         modalRole: "edit",
       }),
     );
+    dispatch(setLecture(lecture));
   };
 
   return (

--- a/src/app/classroom/(components)/main/ContentInfo.tsx
+++ b/src/app/classroom/(components)/main/ContentInfo.tsx
@@ -7,6 +7,8 @@ import {
 import { useRouter } from "next/navigation";
 import { useDispatch } from "react-redux";
 import { ILecture } from "@/hooks/queries/useGetCourseList";
+import useClassroomModal from "@/hooks/lecture/useClassroomModal";
+import { resetInput } from "@/redux/slice/lectureInfoSlice";
 
 interface IProps {
   setDeleteModal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -15,7 +17,7 @@ interface IProps {
 
 const ContentInfo = ({ lecture, setDeleteModal }: IProps) => {
   const { title, lectureType, startDate, endDate, lectureContent } = lecture;
-
+  const { lectureInfo } = useClassroomModal();
   const router = useRouter();
   const dispatch = useDispatch();
   const handleMovePage = () => {
@@ -56,6 +58,7 @@ const ContentInfo = ({ lecture, setDeleteModal }: IProps) => {
         modalRole: "edit",
       }),
     );
+    lectureInfo?.lectureId !== lecture.lectureId && dispatch(resetInput());
     dispatch(setLecture(lecture));
   };
 

--- a/src/app/classroom/(components)/modal/common/ModalMain.tsx
+++ b/src/app/classroom/(components)/modal/common/ModalMain.tsx
@@ -1,13 +1,15 @@
 import React, { FormEvent, ReactNode } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@/redux/store";
 import LectureTitle from "./LectureTitle";
 import ModalFooter from "./ModalFooter";
 import { closeModal } from "@/redux/slice/classroomModalSlice";
 import { resetInput } from "@/redux/slice/lectureInfoSlice";
-import { useCreateLecture } from "@/hooks/mutation/useCreateLecture";
-import useLectureInfo from "@/hooks/lecture/useLectureInfo";
-import { RootState } from "@/redux/store";
 import { resetDropzone } from "@/redux/slice/dropzoneFileSlice";
+import { useCreateLecture } from "@/hooks/mutation/useCreateLecture";
+import { useUpdateLecture } from "@/hooks/mutation/useUpdateLecture";
+import useClassroomModal from "@/hooks/lecture/useClassroomModal";
+import useLectureInfo from "@/hooks/lecture/useLectureInfo";
 
 interface ModalMainProps {
   children: ReactNode;
@@ -15,11 +17,13 @@ interface ModalMainProps {
 
 const ModalMain: React.FC<ModalMainProps> = ({ children }) => {
   const dispatch = useDispatch();
+  const { lectureInfo, modalRole } = useClassroomModal();
+  const CreateMutation = useCreateLecture();
+  const UpdateMutation = useUpdateLecture();
   const lectureCount = useSelector(
     (state: RootState) => state.editCourse.lectureCount,
   );
 
-  const mutation = useCreateLecture();
   const {
     user,
     courseId,
@@ -45,8 +49,8 @@ const ModalMain: React.FC<ModalMainProps> = ({ children }) => {
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (user && lectureType && startDate && endDate) {
-      mutation.mutate({
+    if (modalRole !== "edit" && user && startDate && endDate) {
+      CreateMutation.mutate({
         userId: user.uid,
         courseId: courseId,
         lectureType,
@@ -56,6 +60,25 @@ const ModalMain: React.FC<ModalMainProps> = ({ children }) => {
         endDate,
         isPrivate: isLecturePrivate,
         order: lectureCount + 1,
+      });
+    } else if (
+      modalRole === "edit" &&
+      lectureInfo?.lectureId &&
+      startDate &&
+      endDate
+    ) {
+      UpdateMutation.mutate({
+        lectureId: lectureInfo.lectureId,
+        title: lectureTitle,
+        lectureContent,
+        externalLink,
+        noteImages,
+        textContent,
+        videoURL,
+        videoLength,
+        startDate,
+        endDate,
+        isPrivate: isLecturePrivate,
       });
     }
     dispatch(closeModal());

--- a/src/app/classroom/(components)/modal/createLecture/AddLinkModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/AddLinkModal.tsx
@@ -3,14 +3,16 @@ import { useDispatch } from "react-redux";
 import Layout from "../common/Layout";
 import ModalHeader from "../common/ModalHeader";
 import ModalMain from "../common/ModalMain";
-import { setExternalLink } from "@/redux/slice/lectureInfoSlice";
 import useClassroomModal from "@/hooks/lecture/useClassroomModal";
 import useLectureInfo from "@/hooks/lecture/useLectureInfo";
+import useFirebaseLectureSlice from "@/hooks/lecture/useFirebaseLectureSlice";
+import { setExternalLink } from "@/redux/slice/lectureInfoSlice";
 
 const AddLinkModal: React.FC = () => {
   const dispatch = useDispatch();
   const { modalRole, handleModalMove } = useClassroomModal();
   const { externalLink } = useLectureInfo();
+  useFirebaseLectureSlice();
   const MODAL_ROLE_OBJ: { [key: string]: string } = {
     create: "링크 만들기",
     edit: "수정하기",

--- a/src/app/classroom/(components)/modal/createLecture/AddNoteModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/AddNoteModal.tsx
@@ -3,13 +3,16 @@ import Layout from "../common/Layout";
 import ModalHeader from "../common/ModalHeader";
 import ModalMain from "../common/ModalMain";
 import useClassroomModal from "@/hooks/lecture/useClassroomModal";
+import useFirebaseLectureSlice from "@/hooks/lecture/useFirebaseLectureSlice";
 
 const NoSsrEditor = dynamic(() => import("./NoteSection"), {
   ssr: false,
+  loading: () => <div>Loading...</div>,
 });
 
 const AddNoteModal: React.FC = () => {
   const { modalRole, handleModalMove } = useClassroomModal();
+  useFirebaseLectureSlice();
   const MODAL_ROLE_OBJ: { [key: string]: string } = {
     create: "노트 만들기",
     edit: "수정하기",

--- a/src/app/classroom/(components)/modal/createLecture/AddVideoFileModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/AddVideoFileModal.tsx
@@ -9,6 +9,7 @@ import DropzoneSection from "./DropzoneSection";
 import PageToast from "@/components/PageToast";
 import useClassroomModal from "@/hooks/lecture/useClassroomModal";
 import useVideoFileDrop from "@/hooks/lecture/useVideoFileDrop";
+import useFirebaseLectureSlice from "@/hooks/lecture/useFirebaseLectureSlice";
 import {
   setErrorMessage,
   setSuccessMessage,
@@ -16,6 +17,8 @@ import {
 
 const AddVideoFileModal: React.FC = () => {
   const dispatch = useDispatch();
+  useFirebaseLectureSlice();
+
   const videoFileName = useSelector(
     (state: RootState) => state.dropzoneFile.videoFileName,
   );

--- a/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
@@ -4,6 +4,7 @@ import { Editor } from "@toast-ui/react-editor";
 import { setNoteImages, setTextContent } from "@/redux/slice/lectureInfoSlice";
 import useLectureInfo from "@/hooks/lecture/useLectureInfo";
 import useUploadImage from "@/hooks/lecture/useUploadImage";
+import useClassroomModal from "@/hooks/lecture/useClassroomModal";
 import "@toast-ui/editor/dist/toastui-editor.css";
 
 type HookCallback = (url: string, text?: string) => void;
@@ -11,9 +12,13 @@ type HookCallback = (url: string, text?: string) => void;
 const NoteSction: React.FC = () => {
   const editorRef = useRef<Editor>(null);
   const dispatch = useDispatch();
+  const { lectureInfo, modalRole } = useClassroomModal();
   const { onUploadImage } = useUploadImage();
   const { textContent } = useLectureInfo();
-
+  const currentValue =
+    modalRole === "edit"
+      ? lectureInfo?.lectureContent.textContent
+      : textContent;
   const toolbarItems = [
     ["heading", "bold", "italic", "strike"],
     ["image", "link"],
@@ -41,7 +46,7 @@ const NoteSction: React.FC = () => {
   return (
     <Editor
       ref={editorRef}
-      initialValue={textContent}
+      initialValue={currentValue}
       placeholder="내용을 입력해주세요."
       hideModeSwitch={true}
       usageStatistics={false}

--- a/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/NoteSection.tsx
@@ -1,8 +1,8 @@
-import { useRef, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useRef } from "react";
+import { useDispatch } from "react-redux";
 import { Editor } from "@toast-ui/react-editor";
-import { RootState } from "@/redux/store";
 import { setNoteImages, setTextContent } from "@/redux/slice/lectureInfoSlice";
+import useLectureInfo from "@/hooks/lecture/useLectureInfo";
 import useUploadImage from "@/hooks/lecture/useUploadImage";
 import "@toast-ui/editor/dist/toastui-editor.css";
 
@@ -11,11 +11,8 @@ type HookCallback = (url: string, text?: string) => void;
 const NoteSction: React.FC = () => {
   const editorRef = useRef<Editor>(null);
   const dispatch = useDispatch();
-  const textContent = useSelector(
-    (state: RootState) => state.lectureInfo.textContent,
-  );
-  const [content, setContent] = useState<string | undefined>(textContent);
   const { onUploadImage } = useUploadImage();
+  const { textContent } = useLectureInfo();
 
   const toolbarItems = [
     ["heading", "bold", "italic", "strike"],
@@ -27,7 +24,6 @@ const NoteSction: React.FC = () => {
     const newContent: string | undefined = editorRef.current
       ?.getInstance()
       .getMarkdown();
-    setContent(newContent);
     dispatch(setTextContent(newContent));
   };
 
@@ -45,7 +41,7 @@ const NoteSction: React.FC = () => {
   return (
     <Editor
       ref={editorRef}
-      initialValue={content}
+      initialValue={textContent}
       placeholder="내용을 입력해주세요."
       hideModeSwitch={true}
       usageStatistics={false}

--- a/src/hooks/lecture/useClassroomModal.tsx
+++ b/src/hooks/lecture/useClassroomModal.tsx
@@ -26,6 +26,9 @@ const useClassroomModal = () => {
   const modalRole = useSelector(
     (state: RootState) => state.classroomModal.modalRole,
   );
+  const lecture = useSelector(
+    (state: RootState) => state.classroomModal.lecture,
+  );
 
   const handleModalMove = (openModalName: string, closeModalName: string) => {
     dispatch(
@@ -52,6 +55,7 @@ const useClassroomModal = () => {
     commentModalOpen,
     replyCommentModalOpen,
     modalRole,
+    lecture,
     handleModalMove,
   };
 };

--- a/src/hooks/lecture/useClassroomModal.tsx
+++ b/src/hooks/lecture/useClassroomModal.tsx
@@ -26,8 +26,8 @@ const useClassroomModal = () => {
   const modalRole = useSelector(
     (state: RootState) => state.classroomModal.modalRole,
   );
-  const lecture = useSelector(
-    (state: RootState) => state.classroomModal.lecture,
+  const lectureInfo = useSelector(
+    (state: RootState) => state.classroomModal.lectureInfo,
   );
 
   const handleModalMove = (openModalName: string, closeModalName: string) => {
@@ -55,7 +55,7 @@ const useClassroomModal = () => {
     commentModalOpen,
     replyCommentModalOpen,
     modalRole,
-    lecture,
+    lectureInfo,
     handleModalMove,
   };
 };

--- a/src/hooks/lecture/useFirebaseLectureSlice.ts
+++ b/src/hooks/lecture/useFirebaseLectureSlice.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import useClassroomModal from "./useClassroomModal";
+import {
+  setCourseId,
+  setEndDate,
+  setExternalLink,
+  setIsLecturePrivate,
+  setLectureTitle,
+  setLectureType,
+  setStartDate,
+} from "@/redux/slice/lectureInfoSlice";
+
+
+const useFirebaseLectureSlice = () => {
+  const dispatch = useDispatch();
+  const { lecture } = useClassroomModal();
+
+  useEffect(() => {
+    if (lecture) {
+      dispatch(setCourseId(lecture.courseId));
+      dispatch(setLectureType(lecture.lectureType));
+      dispatch(setLectureTitle(lecture.title));
+      dispatch(setExternalLink(lecture.lectureContent.externalLink));
+      dispatch(setStartDate(lecture.startDate));
+      dispatch(setEndDate(lecture.endDate));
+      dispatch(setIsLecturePrivate(lecture.isPrivate));
+    }
+  }, [dispatch, lecture]);
+};
+
+export default useFirebaseLectureSlice;

--- a/src/hooks/lecture/useFirebaseLectureSlice.ts
+++ b/src/hooks/lecture/useFirebaseLectureSlice.ts
@@ -3,14 +3,19 @@ import { useDispatch } from "react-redux";
 import useClassroomModal from "./useClassroomModal";
 import {
   setCourseId,
-  setEndDate,
-  setExternalLink,
-  setIsLecturePrivate,
-  setLectureTitle,
   setLectureType,
+  setLectureTitle,
+  setExternalLink,
+  setVideoURL,
+  setVideoLength,
   setStartDate,
+  setEndDate,
+  setIsLecturePrivate,
 } from "@/redux/slice/lectureInfoSlice";
-
+import {
+  setErrorMessage,
+  setVideoFileName,
+} from "@/redux/slice/dropzoneFileSlice";
 
 const useFirebaseLectureSlice = () => {
   const dispatch = useDispatch();
@@ -22,9 +27,25 @@ const useFirebaseLectureSlice = () => {
       dispatch(setLectureType(lecture.lectureType));
       dispatch(setLectureTitle(lecture.title));
       dispatch(setExternalLink(lecture.lectureContent.externalLink));
+      dispatch(setVideoURL(lecture.lectureContent.videoUrl));
+      dispatch(setVideoLength(lecture.lectureContent.videoLength));
       dispatch(setStartDate(lecture.startDate));
       dispatch(setEndDate(lecture.endDate));
       dispatch(setIsLecturePrivate(lecture.isPrivate));
+
+      if (lecture.lectureContent.videoUrl) {
+        const urlParts = lecture.lectureContent.videoUrl
+          .split("?")[0]
+          .split("/");
+        const filePath = decodeURIComponent(urlParts[urlParts.length - 1]);
+        const fileName = filePath.split("/")[2];
+        dispatch(setVideoFileName(fileName));
+        dispatch(
+          setErrorMessage(
+            "이미 사용 중인 파일이 있습니다. 기존의 파일을 삭제하고 진행해주세요.",
+          ),
+        );
+      }
     }
   }, [dispatch, lecture]);
 };

--- a/src/hooks/lecture/useFirebaseLectureSlice.ts
+++ b/src/hooks/lecture/useFirebaseLectureSlice.ts
@@ -6,6 +6,8 @@ import {
   setLectureType,
   setLectureTitle,
   setExternalLink,
+  setTextContent,
+  setNoteImages,
   setVideoURL,
   setVideoLength,
   setStartDate,
@@ -27,6 +29,8 @@ const useFirebaseLectureSlice = () => {
       dispatch(setLectureType(lecture.lectureType));
       dispatch(setLectureTitle(lecture.title));
       dispatch(setExternalLink(lecture.lectureContent.externalLink));
+      dispatch(setTextContent(lecture.lectureContent.textContent));
+      dispatch(setNoteImages(lecture.lectureContent.images));
       dispatch(setVideoURL(lecture.lectureContent.videoUrl));
       dispatch(setVideoLength(lecture.lectureContent.videoLength));
       dispatch(setStartDate(lecture.startDate));

--- a/src/hooks/lecture/useFirebaseLectureSlice.ts
+++ b/src/hooks/lecture/useFirebaseLectureSlice.ts
@@ -21,24 +21,22 @@ import {
 
 const useFirebaseLectureSlice = () => {
   const dispatch = useDispatch();
-  const { lecture } = useClassroomModal();
+  const { lectureInfo } = useClassroomModal();
 
   useEffect(() => {
-    if (lecture) {
-      dispatch(setCourseId(lecture.courseId));
-      dispatch(setLectureType(lecture.lectureType));
-      dispatch(setLectureTitle(lecture.title));
-      dispatch(setExternalLink(lecture.lectureContent.externalLink));
-      dispatch(setTextContent(lecture.lectureContent.textContent));
-      dispatch(setNoteImages(lecture.lectureContent.images));
-      dispatch(setVideoURL(lecture.lectureContent.videoUrl));
-      dispatch(setVideoLength(lecture.lectureContent.videoLength));
-      dispatch(setStartDate(lecture.startDate));
-      dispatch(setEndDate(lecture.endDate));
-      dispatch(setIsLecturePrivate(lecture.isPrivate));
+    if (lectureInfo) {
+      dispatch(setLectureTitle(lectureInfo.title));
+      dispatch(setExternalLink(lectureInfo.lectureContent.externalLink));
+      dispatch(setTextContent(lectureInfo.lectureContent.textContent));
+      dispatch(setNoteImages(lectureInfo.lectureContent.images));
+      dispatch(setVideoURL(lectureInfo.lectureContent.videoUrl));
+      dispatch(setVideoLength(lectureInfo.lectureContent.videoLength));
+      dispatch(setStartDate(lectureInfo.startDate));
+      dispatch(setEndDate(lectureInfo.endDate));
+      dispatch(setIsLecturePrivate(lectureInfo.isPrivate));
 
-      if (lecture.lectureContent.videoUrl) {
-        const urlParts = lecture.lectureContent.videoUrl
+      if (lectureInfo.lectureContent.videoUrl) {
+        const urlParts = lectureInfo.lectureContent.videoUrl
           .split("?")[0]
           .split("/");
         const filePath = decodeURIComponent(urlParts[urlParts.length - 1]);
@@ -51,7 +49,7 @@ const useFirebaseLectureSlice = () => {
         );
       }
     }
-  }, [dispatch, lecture]);
+  }, [dispatch, lectureInfo]);
 };
 
 export default useFirebaseLectureSlice;

--- a/src/hooks/mutation/useUpdateLecture.ts
+++ b/src/hooks/mutation/useUpdateLecture.ts
@@ -1,0 +1,67 @@
+import { LectureContent } from "@/types/firebase.types";
+import { db } from "@/utils/firebase";
+import { doc, serverTimestamp, Timestamp, updateDoc } from "firebase/firestore";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { QUERY_KEY } from "@/constants/queryKey";
+
+interface LectureInfoType {
+  lectureId: string;
+  title: string;
+  externalLink: string;
+  noteImages?: string[];
+  textContent: string;
+  videoURL: string;
+  videoLength: number;
+  lectureContent: LectureContent;
+  startDate: Timestamp;
+  endDate: Timestamp;
+  isPrivate: boolean;
+}
+
+const LectureInfo = async (data: LectureInfoType) => {
+  const {
+    lectureId,
+    title,
+    externalLink,
+    noteImages,
+    textContent,
+    videoURL,
+    videoLength,
+    startDate,
+    endDate,
+    isPrivate,
+  } = data;
+
+  try {
+    const lectureRef = doc(db, "lectures", lectureId);
+    const lectureDoc = {
+      title,
+      "lectureContent.externalLink": externalLink,
+      // "lectureContent.images": noteImages,
+      "lectureContent.textContent": textContent,
+      "lectureContent.videoUrl": videoURL,
+      "lectureContent.videoLength": videoLength,
+      startDate,
+      endDate,
+      isPrivate,
+      updatedAt: serverTimestamp(),
+    };
+    await updateDoc(lectureRef, lectureDoc);
+  } catch (error) {
+    console.error("강의 수정 중 오류가 발생했습니다:", error);
+  }
+};
+
+export const useUpdateLecture = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(LectureInfo, {
+    onSuccess: data => {
+      console.log(data);
+      queryClient.invalidateQueries([QUERY_KEY.COURSE]);
+    },
+    onError: error => {
+      console.error("강의 수정에 실패했습니다: ", error);
+    },
+  });
+};

--- a/src/redux/slice/classroomModalSlice.tsx
+++ b/src/redux/slice/classroomModalSlice.tsx
@@ -9,7 +9,7 @@ interface ModalState {
   commentModalOpen: boolean;
   replyCommentModalOpen: boolean;
   modalRole: string;
-  lecture: ILecture | null;
+  lectureInfo: ILecture | null;
   [key: string]: boolean | string | ILecture | null;
 }
 
@@ -21,7 +21,7 @@ const initialState: ModalState = {
   commentModalOpen: false,
   replyCommentModalOpen: false,
   modalRole: "",
-  lecture: null,
+  lectureInfo: null,
 };
 
 const classroomModalSlice = createSlice({
@@ -41,7 +41,7 @@ const classroomModalSlice = createSlice({
       state.modalRole = modalRole;
     },
     setLecture: (state, action: PayloadAction<ILecture | null>) => {
-      state.lecture = action.payload;
+      state.lectureInfo = action.payload;
     },
     closeModal: () => initialState,
   },

--- a/src/redux/slice/classroomModalSlice.tsx
+++ b/src/redux/slice/classroomModalSlice.tsx
@@ -1,3 +1,4 @@
+import { ILecture } from "@/hooks/queries/useGetCourseList";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 interface ModalState {
@@ -7,9 +8,9 @@ interface ModalState {
   videoFileModalOpen: boolean;
   commentModalOpen: boolean;
   replyCommentModalOpen: boolean;
-  lectureId: string | null;
   modalRole: string;
-  [key: string]: boolean | string | null;
+  lecture: ILecture | null;
+  [key: string]: boolean | string | ILecture | null;
 }
 
 const initialState: ModalState = {
@@ -19,8 +20,8 @@ const initialState: ModalState = {
   videoFileModalOpen: false,
   commentModalOpen: false,
   replyCommentModalOpen: false,
-  lectureId: null,
   modalRole: "",
+  lecture: null,
 };
 
 const classroomModalSlice = createSlice({
@@ -39,9 +40,13 @@ const classroomModalSlice = createSlice({
       state[modalName] = visible;
       state.modalRole = modalRole;
     },
+    setLecture: (state, action: PayloadAction<ILecture | null>) => {
+      state.lecture = action.payload;
+    },
     closeModal: () => initialState,
   },
 });
 
-export const { setModalVisibility, closeModal } = classroomModalSlice.actions;
+export const { setModalVisibility, setLecture, closeModal } =
+  classroomModalSlice.actions;
 export default classroomModalSlice.reducer;


### PR DESCRIPTION
## 개요 :mag:
* 강의 수정버튼 클릭시 해당하는 노크/비디오/링크 모달에서 현재 강의 정보를 렌더링하여 보여줌
* 강의 수정버튼 클릭시 받아온 강의 정보 상태 관리(업데이트를 위해)
* toast ui editor의 경우 ssr 미지원으로 인해 렌더링 속도 차이가 발생하여 노트 정보가 바로 렌더링되지않음
  * 해결방법 : 조건문을 설정하여 모달의역할이 edit일 경우 강의 정보를 직접적으로 받아와 초기값으로 넣어줌.  
* 강의 수정 후 업데이트를 위한 mutation 커스텀 훅 구현
* 강의 추가/강의 수정을 구분하여 업로드 버튼시 해당 mutation 실행하도록 구현

## 작업사항 :memo:
* close #324 
