### PR TITLE
Update: 강의 수정시 기존 비디오 파일 삭제에 대한 처리 구현

### DIFF
--- a/src/app/classroom/(components)/modal/common/ModalMain.tsx
+++ b/src/app/classroom/(components)/modal/common/ModalMain.tsx
@@ -10,6 +10,7 @@ import { useCreateLecture } from "@/hooks/mutation/useCreateLecture";
 import { useUpdateLecture } from "@/hooks/mutation/useUpdateLecture";
 import useClassroomModal from "@/hooks/lecture/useClassroomModal";
 import useLectureInfo from "@/hooks/lecture/useLectureInfo";
+import useDeleteFile from "@/hooks/lecture/useDeleteFile";
 import {
   clearError,
   resetInput,
@@ -25,8 +26,12 @@ const ModalMain: React.FC<ModalMainProps> = ({ children }) => {
   const { lectureInfo, modalRole } = useClassroomModal();
   const CreateMutation = useCreateLecture();
   const UpdateMutation = useUpdateLecture();
+  const { onDeleteFile } = useDeleteFile();
   const lectureCount = useSelector(
     (state: RootState) => state.editCourse.lectureCount,
+  );
+  const videoToDeleteOnEdit = useSelector(
+    (state: RootState) => state.dropzoneFile.videoToDeleteOnEdit,
   );
   const errorMessage = useSelector(
     (state: RootState) => state.lectureInfo.errorMessage,
@@ -118,6 +123,7 @@ const ModalMain: React.FC<ModalMainProps> = ({ children }) => {
         endDate,
         isPrivate: isLecturePrivate,
       });
+      videoToDeleteOnEdit && onDeleteFile(videoToDeleteOnEdit);
     }
     dispatch(closeModal());
     dispatch(resetInput());

--- a/src/hooks/lecture/useDeleteFile.ts
+++ b/src/hooks/lecture/useDeleteFile.ts
@@ -2,6 +2,7 @@ import { useDispatch } from "react-redux";
 import { storage } from "@/utils/firebase";
 import { deleteObject, ref } from "firebase/storage";
 import { resetDropzone } from "@/redux/slice/dropzoneFileSlice";
+import { setVideoLength, setVideoURL } from "@/redux/slice/lectureInfoSlice";
 
 const useDeleteFile = () => {
   const dispatch = useDispatch();
@@ -11,6 +12,8 @@ const useDeleteFile = () => {
     try {
       await deleteObject(fileRef);
       dispatch(resetDropzone());
+      dispatch(setVideoURL(""));
+      dispatch(setVideoLength(0));
     } catch (error) {
       console.error("Error delete file:", error);
     }

--- a/src/hooks/lecture/useFirebaseLectureSlice.ts
+++ b/src/hooks/lecture/useFirebaseLectureSlice.ts
@@ -1,9 +1,7 @@
 import { useEffect } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import useClassroomModal from "./useClassroomModal";
 import {
-  setCourseId,
-  setLectureType,
   setLectureTitle,
   setExternalLink,
   setTextContent,

--- a/src/hooks/lecture/useVideoFileDrop.tsx
+++ b/src/hooks/lecture/useVideoFileDrop.tsx
@@ -2,10 +2,16 @@ import { useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/redux/store";
 import { FileRejection, useDropzone } from "react-dropzone";
-import { setErrorMessage } from "@/redux/slice/dropzoneFileSlice";
+import {
+  setErrorMessage,
+  setVideoFileName,
+  setVideoToDeleteOnEdit,
+} from "@/redux/slice/dropzoneFileSlice";
 import useUploadVideo from "./useUploadVideo";
 import useDeleteFile from "./useDeleteFile";
 import useLectureInfo from "./useLectureInfo";
+import useClassroomModal from "./useClassroomModal";
+import { setVideoLength, setVideoURL } from "@/redux/slice/lectureInfoSlice";
 
 const useVideoFileDrop = () => {
   const dispatch = useDispatch();
@@ -15,6 +21,7 @@ const useVideoFileDrop = () => {
   const { onUploadVideo } = useUploadVideo();
   const { onDeleteFile } = useDeleteFile();
   const { videoURL } = useLectureInfo();
+  const { lectureInfo, modalRole } = useClassroomModal();
 
   const onDrop = useCallback(
     (acceptedFiles: File[], fileRejections: FileRejection[]) => {
@@ -47,7 +54,18 @@ const useVideoFileDrop = () => {
   );
 
   const handleRemoveVideoFile = () => {
-    onDeleteFile(videoURL);
+    if (
+      modalRole === "edit" &&
+      lectureInfo?.lectureContent.videoUrl === videoURL
+    ) {
+      dispatch(setVideoToDeleteOnEdit(videoURL));
+      dispatch(setVideoURL(""));
+      dispatch(setVideoLength(0));
+      dispatch(setVideoFileName(""));
+      dispatch(setErrorMessage(""));
+    } else {
+      onDeleteFile(videoURL);
+    }
   };
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({

--- a/src/redux/slice/dropzoneFileSlice.tsx
+++ b/src/redux/slice/dropzoneFileSlice.tsx
@@ -2,12 +2,14 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 interface DropzoneFileState {
   videoFileName: string;
+  videoToDeleteOnEdit: string;
   errorMessage: string;
   successMessage: string;
 }
 
 const initialState: DropzoneFileState = {
   videoFileName: "",
+  videoToDeleteOnEdit: "",
   errorMessage: "",
   successMessage: "",
 };
@@ -18,6 +20,9 @@ const dropzoneFileSlice = createSlice({
   reducers: {
     setVideoFileName: (state, action: PayloadAction<string>) => {
       state.videoFileName = action.payload;
+    },
+    setVideoToDeleteOnEdit: (state, action: PayloadAction<string>) => {
+      state.videoToDeleteOnEdit = action.payload;
     },
     setErrorMessage: (state, action: PayloadAction<string>) => {
       state.errorMessage = action.payload;
@@ -31,6 +36,7 @@ const dropzoneFileSlice = createSlice({
 
 export const {
   setVideoFileName,
+  setVideoToDeleteOnEdit,
   setErrorMessage,
   setSuccessMessage,
   resetDropzone,


### PR DESCRIPTION
## 개요 :mag:
* 기존에는 비디오 강의 수정에서 강의 정보만 불러오고, 비디오 파일 삭제가 불가능했음.
* 우선 삭제 버튼 클릭시 storage에서 바로 삭제를 해버리면, 모달창을 벗어났다가 다시 수정하고자 들어왔을때, 문제가 발생함.
(storage에는 비디오파일이 없는데, 존재하지않는 비디오 강의 정보를 불어오려고 하기때문에)
* 이에 우선 삭제 버튼 클릭시 해당 비디오파일 url을 상태관리하고, 사용자가 새로운 비디오파일을 추가하고 업로드 버튼을 클릭하였을때, 새로운 강의 정보 업데이트 후 기존 비디오파일을 삭제하도록 구현하였음. 

## 작업사항 :memo:
* close #340 