### PR TITLE
Feat: 비디오 강의 삭제시 비디오 파일 storage에서 삭제

### DIFF
--- a/src/app/classroom/(components)/main/ContentCard.tsx
+++ b/src/app/classroom/(components)/main/ContentCard.tsx
@@ -1,9 +1,12 @@
-import { ILecture } from "@/hooks/queries/useGetCourseList";
+import { useDispatch } from "react-redux";
 import ContentImg from "./ContentImg";
 import ContentInfo from "./ContentInfo";
 import LectureDeleteModal from "../modal/createLecture/LectureDeleteModal";
-import { useState } from "react";
+import useClassroomModal from "@/hooks/lecture/useClassroomModal";
+import useDeleteFile from "@/hooks/lecture/useDeleteFile";
+import { ILecture } from "@/hooks/queries/useGetCourseList";
 import useDeleteLecture from "@/hooks/mutation/useDeleteLecture";
+import { setModalVisibility } from "@/redux/slice/classroomModalSlice";
 
 const ContentCard = ({
   lecture,
@@ -12,31 +15,36 @@ const ContentCard = ({
   lecture: ILecture;
   role: string;
 }) => {
-  const [deleteModal, setDeleteModal] = useState(false);
+  const dispatch = useDispatch();
+  const { lectureInfo, lectureDeleteModalOpen } = useClassroomModal();
+  const { onDeleteFile } = useDeleteFile();
   const { mutate: deleteLecture } = useDeleteLecture(lecture.lectureId);
+
+  const deleteModalClose = () => {
+    dispatch(
+      setModalVisibility({
+        modalName: "lectureDeleteModalOpen",
+        visible: false,
+        modalRole: "delete",
+      }),
+    );
+  };
+
   return (
     <>
       <div className="w-[775px] h-[200px] border rounded-lg p-[10px] flex flex-row items-center mb-[15px]">
         <ContentImg isPrivate={lecture.isPrivate} />
-        <ContentInfo
-          lecture={lecture}
-          setDeleteModal={setDeleteModal}
-          role={role}
-        />
+        <ContentInfo lecture={lecture} role={role} />
       </div>
-      {deleteModal && (
+      {lectureDeleteModalOpen && (
         <LectureDeleteModal
-          onCancel={() => setDeleteModal(false)}
-          onDelete={() =>
-            deleteLecture(
-              {},
-              {
-                onSuccess: () => {
-                  setDeleteModal(false);
-                },
-              },
-            )
-          }
+          onCancel={deleteModalClose}
+          onDelete={() => {
+            deleteLecture();
+            deleteModalClose();
+            lectureInfo?.lectureContent.videoUrl &&
+              onDeleteFile(lectureInfo?.lectureContent.videoUrl);
+          }}
         />
       )}
     </>

--- a/src/app/classroom/(components)/main/ContentInfo.tsx
+++ b/src/app/classroom/(components)/main/ContentInfo.tsx
@@ -11,25 +11,32 @@ import useClassroomModal from "@/hooks/lecture/useClassroomModal";
 import { resetInput } from "@/redux/slice/lectureInfoSlice";
 
 interface IProps {
-  setDeleteModal: React.Dispatch<React.SetStateAction<boolean>>;
   lecture: ILecture;
   role: string;
 }
 
-const ContentInfo = ({ lecture, setDeleteModal, role }: IProps) => {
-  const { title, lectureType, startDate, endDate, lectureContent } = lecture;
-  const { lectureInfo } = useClassroomModal();
-  const router = useRouter();
+const ContentInfo = ({ lecture, role }: IProps) => {
   const dispatch = useDispatch();
-  console.log(lecture);
+  const router = useRouter();
+  const { lectureInfo } = useClassroomModal();
+  const { title, lectureType, startDate, endDate, lectureContent } = lecture;
+
   const handleMovePage = () => {
     if (lecture.lectureType === "링크") {
       return window.open(`${lecture.lectureContent.externalLink}`);
     }
     router.push(`/classroom/${lecture.lectureId}`);
   };
+
   const handleDeleteModal = () => {
-    setDeleteModal(true);
+    dispatch(setLecture(lecture));
+    dispatch(
+      setModalVisibility({
+        modalName: "lectureDeleteModalOpen",
+        visible: true,
+        modalRole: "delete",
+      }),
+    );
   };
 
   const [start, end] = [timestampToDate(startDate), timestampToDate(endDate)];

--- a/src/hooks/lecture/useClassroomModal.tsx
+++ b/src/hooks/lecture/useClassroomModal.tsx
@@ -23,6 +23,9 @@ const useClassroomModal = () => {
   const replyCommentModalOpen = useSelector(
     (state: RootState) => state.classroomModal.replyCommentModalOpen,
   );
+  const lectureDeleteModalOpen = useSelector(
+    (state: RootState) => state.classroomModal.lectureDeleteModalOpen,
+  );
   const modalRole = useSelector(
     (state: RootState) => state.classroomModal.modalRole,
   );
@@ -54,6 +57,7 @@ const useClassroomModal = () => {
     videoFileModalOpen,
     commentModalOpen,
     replyCommentModalOpen,
+    lectureDeleteModalOpen,
     modalRole,
     lectureInfo,
     handleModalMove,

--- a/src/redux/slice/classroomModalSlice.tsx
+++ b/src/redux/slice/classroomModalSlice.tsx
@@ -8,6 +8,7 @@ interface ModalState {
   videoFileModalOpen: boolean;
   commentModalOpen: boolean;
   replyCommentModalOpen: boolean;
+  lectureDeleteModalOpen: boolean;
   modalRole: string;
   lectureInfo: ILecture | null;
   [key: string]: boolean | string | ILecture | null;
@@ -20,6 +21,7 @@ const initialState: ModalState = {
   videoFileModalOpen: false,
   commentModalOpen: false,
   replyCommentModalOpen: false,
+  lectureDeleteModalOpen: false,
   modalRole: "",
   lectureInfo: null,
 };


### PR DESCRIPTION
## 개요 :mag:
강의 삭제 모달을 모달 open/close를 관리하는 slice에 추가하여 상태 관리하였음.
기존에는 비디오 강의 삭제시 firestore에 있는 강의 doc만 삭제되고, storage에서는 삭제되지않았음.
삭제하고자하는 강의정보에 비디오파일 url이 존재한다면, 비디오 강의란 뜻이므로 storage에서도 해당하는 비디오 파일을 삭제할 수 있도록 구현하였음

## 작업사항 :memo:
* close #349 

