### PR TITLE
Update: storage 동일 파일명 overwriting 이슈로 독립적인 파일명으로 변경 후 업로드로 변경 외

### DIFF
--- a/src/app/assignment/(components)/AssignmentDetailContent.tsx
+++ b/src/app/assignment/(components)/AssignmentDetailContent.tsx
@@ -18,11 +18,11 @@ import timestampToIntlDate from "@/utils/timestampToIntlDate";
 import { useUpdateReadStudents } from "@/hooks/mutation/useUpdateReadStudents";
 import useGetStudents from "@/hooks/queries/useGetStudents";
 
-interface OwnProps {
+interface IUserProps {
   user: User;
 }
 
-const AssignmentDetailContent: React.FC<OwnProps> = ({ user }) => {
+const AssignmentDetailContent = ({ user }: IUserProps) => {
   const router = useRouter();
 
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);

--- a/src/app/assignment/(components)/AssignmentGlobalConfirmDialog.tsx
+++ b/src/app/assignment/(components)/AssignmentGlobalConfirmDialog.tsx
@@ -1,6 +1,6 @@
 import { Button, Title } from "sfac-designkit-react";
 
-type OwnProps = {
+type tAssignmentGlobalConfirmDialogProps = {
   onConfirm: () => void;
   onCancel: () => void;
   isOpen: boolean;
@@ -8,13 +8,13 @@ type OwnProps = {
   confirmBtnMsg: string; // 컨펌 확인 버튼 글자
 };
 
-const AssignmentGlobalConfirmDialog: React.FC<OwnProps> = ({
+const AssignmentGlobalConfirmDialog = ({
   onConfirm,
   onCancel,
   isOpen,
   title,
   confirmBtnMsg,
-}) => {
+}: tAssignmentGlobalConfirmDialogProps) => {
   return (
     <>
       <div

--- a/src/app/assignment/(components)/AssignmentLocalConfirmDialog.tsx
+++ b/src/app/assignment/(components)/AssignmentLocalConfirmDialog.tsx
@@ -1,6 +1,6 @@
 import { Button, Text } from "sfac-designkit-react";
 
-type OwnProps = {
+type TAssignmentLocalConfirmDialogProps = {
   onConfirm: () => void;
   onCancel: () => void;
   isOpen: boolean;
@@ -9,14 +9,14 @@ type OwnProps = {
   confirmBtnMsg: string; // 컨펌 확인 버튼 글자
 };
 
-const AssignmentLocalConfirmDialog: React.FC<OwnProps> = ({
+const AssignmentLocalConfirmDialog = ({
   onConfirm,
   onCancel,
   isOpen,
   title,
   content,
   confirmBtnMsg,
-}) => {
+}: TAssignmentLocalConfirmDialogProps) => {
   return (
     <>
       <div

--- a/src/app/assignment/(components)/AssignmentModal.tsx
+++ b/src/app/assignment/(components)/AssignmentModal.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
 import { ReactNode } from "react";
-import { Text, Title } from "sfac-designkit-react";
+import { Title } from "sfac-designkit-react";
 
-type OwnProps = {
+type TAssignmentModalProps = {
   title: string;
   isOpen: boolean;
   isBottomButton: boolean;
@@ -10,13 +10,13 @@ type OwnProps = {
   children: ReactNode;
 };
 
-const AssignmentModal: React.FC<OwnProps> = ({
+const AssignmentModal = ({
   title,
   isOpen,
   isBottomButton,
   onClose,
   children,
-}) => {
+}: TAssignmentModalProps) => {
   return (
     <div
       className={`fixed w-screen h-screen z-50 left-0 top-0 flex justify-center items-center transition-opacity duration-300 ${

--- a/src/app/assignment/(components)/AssignmentModal.tsx
+++ b/src/app/assignment/(components)/AssignmentModal.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { ReactNode } from "react";
+import { ReactNode, useEffect } from "react";
 import { Title } from "sfac-designkit-react";
 
 type TAssignmentModalProps = {
@@ -17,6 +17,12 @@ const AssignmentModal = ({
   onClose,
   children,
 }: TAssignmentModalProps) => {
+  useEffect(() => {
+    isOpen
+      ? (document.body.style.overflow = "hidden")
+      : (document.body.style.overflow = "visible");
+  }, [isOpen]);
+
   return (
     <div
       className={`fixed w-screen h-screen z-50 left-0 top-0 flex justify-center items-center transition-opacity duration-300 ${

--- a/src/app/assignment/(components)/AssignmentProfileImage.tsx
+++ b/src/app/assignment/(components)/AssignmentProfileImage.tsx
@@ -1,10 +1,10 @@
 import Image from "next/image";
 import { SyntheticEvent } from "react";
-interface OwnProps {
+interface IAssignmentProfileImageProps {
   profileImage: string | undefined;
 }
 
-const AssignmentProfileImage: React.FC<OwnProps> = profileImage => {
+const AssignmentProfileImage = (profileImage: IAssignmentProfileImageProps) => {
   const defaultImagePath = "/images/avatar.svg";
 
   const handleError = (event: SyntheticEvent<HTMLImageElement, Event>) => {

--- a/src/app/assignment/(components)/AssignmentSubmitWithFile.tsx
+++ b/src/app/assignment/(components)/AssignmentSubmitWithFile.tsx
@@ -7,17 +7,17 @@ import useFilesUpload from "@/hooks/mutation/useUpdateFiles";
 import { Attachment } from "@/types/firebase.types";
 import { Button, Text, Icon } from "sfac-designkit-react";
 
-type OwnProps = {
+type TAssignmentSubmitWithFileProps = {
   onClose: () => void;
   assignmentId: string;
   userId: string;
 };
 
-const AssignmentSubmitWithFile: React.FC<OwnProps> = ({
+const AssignmentSubmitWithFile = ({
   onClose,
   assignmentId,
   userId,
-}) => {
+}: TAssignmentSubmitWithFileProps) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [toastMsg, setToastMsg] = useState<string>("");
   const [isAccept, setIsAccept] = useState<boolean>(false);

--- a/src/app/assignment/(components)/AssignmentSubmitWithFile.tsx
+++ b/src/app/assignment/(components)/AssignmentSubmitWithFile.tsx
@@ -4,8 +4,7 @@ import { useDropzone } from "react-dropzone";
 import Image from "next/image";
 import { useSubmitAssignment } from "@/hooks/mutation/useSubmitAssignment";
 import useFilesUpload from "@/hooks/mutation/useUpdateFiles";
-import { Attachment } from "@/types/firebase.types";
-import { Button, Text, Icon } from "sfac-designkit-react";
+import { Button, Text } from "sfac-designkit-react";
 
 type TAssignmentSubmitWithFileProps = {
   onClose: () => void;
@@ -59,10 +58,6 @@ const AssignmentSubmitWithFile = ({
   // 컴포넌트의 불필요한 리렌더링을 방지 - 성능 최적화
   const onDrop = useCallback((acceptedFiles: File[]) => {
     setIsDraggedOver(false); // onDrop(파일첨부) 발생하면 border-color 원래대로 변경
-    // 중복 파일 체크
-    const validFiles = acceptedFiles.filter(file =>
-      allowedFileTypes.includes(file.type),
-    );
 
     // 용량 제한 체크
     const oversizedFiles = acceptedFiles.filter(
@@ -127,22 +122,21 @@ const AssignmentSubmitWithFile = ({
       mutate(newAttachmentArray);
       setToastMsg("파일이 업로드되었습니다!");
       setIsAccept(true);
+      setTimeout(() => {
+        onClose();
+      }, 2000);
     } catch (error) {
       setToastMsg("과제 제출에 실패했습니다. 다시 시도해주세요.");
       setIsAccept(false);
     }
-
-    setTimeout(() => {
-      onClose();
-    }, 2000);
   };
 
   const generateUniqueFileName = (originalFileName: string): string => {
     // 랜덤 파일명 생성
-    const timestamp = new Date().getTime(); // 타임스탬프를 사용한 유니크한 값 생성
+    const timestamp = new Date().getTime(); // 현 시각 기준 유니크한 값 생성
     const uniqueString = Math.random().toString(36).substring(7); // 랜덤 문자열 생성
     const fileExtension = originalFileName.split(".").pop(); // 파일 확장자 추출
-    const fileoriginalName = originalFileName.split(".").shift(); // 파일명 추출
+    const fileoriginalName = originalFileName.split(".").shift(); // 원래 파일명 추출
 
     return `${fileoriginalName}_${timestamp}_${uniqueString}.${fileExtension}`;
   };
@@ -254,10 +248,6 @@ const AssignmentSubmitWithFile = ({
       <div className="absolute left-0 bottom-0 w-full min-h-[97px] p-[20px_31px_42px]">
         <div className="flex justify-end items-center gap-[12px]">
           <Button variant="secondary" text="취소" asChild onClick={onClose} />
-
-          {/* <button className="border" type="button" onClick={onClose}>
-            취소
-          </button> */}
           <Button
             variant="primary"
             text="업로드"

--- a/src/app/assignment/(components)/AssignmentSubmitWithFile.tsx
+++ b/src/app/assignment/(components)/AssignmentSubmitWithFile.tsx
@@ -87,13 +87,22 @@ const AssignmentSubmitWithFile = ({
       return;
     }
 
-    // 파일 업로드 진행
+    // 파일 담아두기
     if (acceptedFiles.length > 0) {
-      setSelectedFiles(prevFiles => [...prevFiles, ...acceptedFiles]);
-      // handleUpload(selectedFiles);
+      // 파일명 변경하기
+      const newSelectedFiles: File[] = acceptedFiles.map(file => {
+        const uniqueFileName = generateUniqueFileName(file.name); // 유니크한 파일명 생성
+        return new File([file], uniqueFileName); // 새로운 파일명으로 파일 생성
+      });
+
+      setSelectedFiles(prevFiles => [...prevFiles, ...newSelectedFiles]);
+      // setSelectedFiles(prevFiles => [...prevFiles, ...acceptedFiles]);
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // let newFiles = selectedFiles.map(file => URL.createObjectURL(file));
 
   const handleUpload = async () => {
     // 선택한 파일들의 업로드 수행
@@ -126,6 +135,16 @@ const AssignmentSubmitWithFile = ({
     setTimeout(() => {
       onClose();
     }, 2000);
+  };
+
+  const generateUniqueFileName = (originalFileName: string): string => {
+    // 랜덤 파일명 생성
+    const timestamp = new Date().getTime(); // 타임스탬프를 사용한 유니크한 값 생성
+    const uniqueString = Math.random().toString(36).substring(7); // 랜덤 문자열 생성
+    const fileExtension = originalFileName.split(".").pop(); // 파일 확장자 추출
+    const fileoriginalName = originalFileName.split(".").shift(); // 파일명 추출
+
+    return `${fileoriginalName}_${timestamp}_${uniqueString}.${fileExtension}`;
   };
 
   const handleRemoveFile = (file: File) => {

--- a/src/app/assignment/(components)/AssignmentSubmitWithFile.tsx
+++ b/src/app/assignment/(components)/AssignmentSubmitWithFile.tsx
@@ -136,8 +136,8 @@ const AssignmentSubmitWithFile = ({
     const timestamp = new Date().getTime(); // 현 시각 기준 유니크한 값 생성
     const uniqueString = Math.random().toString(36).substring(7); // 랜덤 문자열 생성
     const fileExtension = originalFileName.split(".").pop(); // 파일 확장자 추출
-    const fileoriginalName = originalFileName.split(".").shift(); // 원래 파일명 추출
-
+    const lastDotIndex = originalFileName.lastIndexOf(".");
+    const fileoriginalName = originalFileName.substring(0, lastDotIndex); // 본래 파일명 추출
     return `${fileoriginalName}_${timestamp}_${uniqueString}.${fileExtension}`;
   };
 
@@ -164,7 +164,7 @@ const AssignmentSubmitWithFile = ({
               return (
                 <div
                   key={index}
-                  className="flex justify-between items-center mb-[20px]"
+                  className="flex justify-between items-center mb-[20px] gap-[5px]"
                 >
                   <div className="flex justify-start items-center gap-[13px]">
                     <div className="w-[36.5px] h-[43.5px]">
@@ -179,7 +179,7 @@ const AssignmentSubmitWithFile = ({
                     <Text
                       size="base"
                       weight="bold"
-                      className="text-primary-80 text-color-Primary-80"
+                      className="text-primary-80 text-color-Primary-80 break-all"
                     >
                       {file.name}
                     </Text>
@@ -187,7 +187,7 @@ const AssignmentSubmitWithFile = ({
                   <div>
                     <button
                       type="button"
-                      className="text-[12px] text-grayscale-100 font-[400]"
+                      className="text-[12px] text-grayscale-100 font-[400] w-[23px] shrink-0"
                       onClick={() => {
                         handleRemoveFile(file);
                       }}

--- a/src/app/assignment/(components)/AssignmentSubmitWithLink.tsx
+++ b/src/app/assignment/(components)/AssignmentSubmitWithLink.tsx
@@ -4,17 +4,17 @@ import Image from "next/image";
 import { useSubmitAssignment } from "@/hooks/mutation/useSubmitAssignment";
 import { Button } from "sfac-designkit-react";
 
-type OwnProps = {
+type TAssignmentSubmitWithLinkProps = {
   onClose: () => void;
   assignmentId: string;
   userId: string;
 };
 
-const AssignmentSubmitWithLink: React.FC<OwnProps> = ({
+const AssignmentSubmitWithLink = ({
   onClose,
   userId,
   assignmentId,
-}) => {
+}: TAssignmentSubmitWithLinkProps) => {
   const [inputValues, setInputValues] = useState<string[]>([""]);
   const [toastMsg, setToastMsg] = useState<string>("");
   const [isAccept, setIsAccept] = useState<boolean>(false);

--- a/src/app/community/(components)/CommunityCard.tsx
+++ b/src/app/community/(components)/CommunityCard.tsx
@@ -139,7 +139,7 @@ const CommunityCard: React.FC<CommunityCardProps> = ({
         <div className="mb-[10px] flex w-full h-[135px]">
           <div className="flex flex-col items-start w-full">
             <h3 className="text-base font-bold mb-[10px]">{title}</h3>
-            <p className="text-sm font-normal text-grayscale-60 mb-[10px] text-left line-clamp-3">
+            <p className="text-sm font-normal text-grayscale-60 mb-[10px] text-left line-clamp-3 whitespace-pre-line">
               {content}
             </p>
             <div>

--- a/src/app/community/(components)/CommunityModal/PostCard.tsx
+++ b/src/app/community/(components)/CommunityModal/PostCard.tsx
@@ -44,7 +44,9 @@ export default function PostCard({
       </div>
       <h2 className="text-base font-bold my-2 ">{postData?.title}</h2>
       <div>
-        <div className="mb-3 w-[710px]">{postData?.content}</div>
+        <div className="mb-3 w-full whitespace-pre-line">
+          {postData?.content}
+        </div>
         <div className="flex">
           {sortedImageData.map((img, idx) => (
             <button key={idx} value={img.name} onClick={handleModalOn}>


### PR DESCRIPTION
## 개요 :mag:

- 프로젝트 리팩토링

## 작업사항 :memo:

- TypeScript type, interface 선언 시 관습적 네이밍으로 변경
- storage 동일 파일명 overwriting 이슈로 독립적인 파일명으로 변경 후 업로드로 변경
- 개행 반영 가능하게 커뮤니티 white-space 변경
- 모달 열렸을 때 body scroll 제한(닫힐 땐 다시 스크롤 visible)
