### PR TITLE
Refactor: 과제 생성 후 생성된 과제 상세 페이지로 이동

### DIFF
--- a/src/app/assignment/(components)/AssignmentCreate.tsx
+++ b/src/app/assignment/(components)/AssignmentCreate.tsx
@@ -13,6 +13,7 @@ import "sfac-designkit-react/style.css";
 import { DateSelector } from "sfac-designkit-react";
 import { Button } from "sfac-designkit-react";
 import { Text } from "sfac-designkit-react";
+import { useRouter } from "next/navigation";
 
 interface AssignmentCreateProps {
   isOpen: boolean;
@@ -47,6 +48,7 @@ const AssignmentCreate: React.FC<AssignmentCreateProps> = ({
 
   const createAssignmentMutation = useCreateAssignment();
   const imageUploadMutation = useImageUpload();
+  const router = useRouter();
 
   const onSubmit: SubmitHandler<AssignmentWithDates> = async assignmentData => {
     if (dates.startDate === null || dates.endDate === null) return onInValid();
@@ -74,7 +76,12 @@ const AssignmentCreate: React.FC<AssignmentCreateProps> = ({
       const uploadedUrls = await Promise.all(uploadPromises);
       assignmentData.images = uploadedUrls;
 
-      createAssignmentMutation.mutate(assignmentData);
+      let assignmentId: string;
+      createAssignmentMutation.mutate(assignmentData, {
+        onSuccess: data => {
+          assignmentId = data.id;
+        },
+      });
 
       setToastMsg("과제가 성공적으로 등록되었습니다.");
       setIsAccept(true);
@@ -87,6 +94,8 @@ const AssignmentCreate: React.FC<AssignmentCreateProps> = ({
           startDate: null,
           endDate: null,
         });
+
+        router.push(`/assignment/${assignmentId}`); // 생성 후 상세 페이지로 이동
       }, 1000);
     } catch (error) {
       setToastMsg("과제 등록에 실패했습니다. 다시 시도해주세요.");


### PR DESCRIPTION
## 개요 :mag:

- 리팩토링: 과제 생성 후 UX 편의성 추가

## 작업사항 :memo:

- 생성되는 과제 id 담아서 생성완료 후 router 이동 처리

## 테스트 방법(optional)

- 과제 생성 -> 생성된 과제의 상세 페이지로 가는지 확인
