### PR TITLE
Refactor : 비디오 파일 저장위치 및 브래드크럼 개선

### DIFF
--- a/src/app/classroom/(components)/modal/common/ModalHeader.tsx
+++ b/src/app/classroom/(components)/modal/common/ModalHeader.tsx
@@ -1,23 +1,50 @@
-import { ReactNode } from "react";
+import useClassroomModal from "@/hooks/lecture/useClassroomModal";
+import Image from "next/image";
 
-interface ModalHeaderProps {
-  children?: ReactNode;
-  currentModalName: string;
+enum ModalNames {
+  linkModalOpen = "링크 만들기",
+  noteModalOpen = "노트 만들기",
+  videoFileModalOpen = "영상 강의 만들기",
 }
 
-const ModalHeader: React.FC<ModalHeaderProps> = ({
-  children,
+const BreadcrumbItem: React.FC<{ label: string }> = ({ label }) => (
+  <>
+    <Image
+      src={"/images/arrow-right.svg"}
+      alt={"다음 페이지로 이동"}
+      width={0}
+      height={0}
+      className="w-[7px] h-[11px]"
+    />
+    <span>{label}</span>
+  </>
+);
+
+const ModalHeader: React.FC<{ currentModalName?: keyof typeof ModalNames }> = ({
   currentModalName,
 }) => {
+  const { modalRole, handleModalMove } = useClassroomModal();
+
   return (
-    <div className="flex gap-[10px] text-xl font-bold text-grayscale-100">
-      {children}
-      {children ? (
-        <span className="relative pl-[17px] before:absolute before:top-[9px] before:left-0 before:w-[7px] before:h-[11px] before:bg-[url('/images/arrow-right.svg')] before:bg-no-repeat before:bg-contain">
-          {currentModalName}
-        </span>
-      ) : (
-        <span>{currentModalName}</span>
+    <div className="flex items-center gap-[10px] text-xl font-bold text-grayscale-100">
+      {modalRole === "create" && !currentModalName && <span>강의 만들기</span>}
+      {modalRole === "create" && currentModalName && (
+        <>
+          <button
+            onClick={() =>
+              handleModalMove("lectureTypeModalOpen", currentModalName)
+            }
+          >
+            강의 만들기
+          </button>
+          <BreadcrumbItem label={ModalNames[currentModalName]} />
+        </>
+      )}
+      {modalRole === "edit" && (
+        <>
+          <span>강의 수정</span>
+          <BreadcrumbItem label="수정하기" />
+        </>
       )}
     </div>
   );

--- a/src/app/classroom/(components)/modal/createLecture/LinkModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/LinkModal.tsx
@@ -2,19 +2,13 @@ import { useDispatch } from "react-redux";
 import Layout from "../common/Layout";
 import ModalHeader from "../common/ModalHeader";
 import ModalMain from "../common/ModalMain";
-import { clearError, setExternalLink } from "@/redux/slice/lectureInfoSlice";
-import useClassroomModal from "@/hooks/lecture/useClassroomModal";
 import useLectureInfo from "@/hooks/lecture/useLectureInfo";
+import { setExternalLink } from "@/redux/slice/lectureInfoSlice";
 import useFirebaseLectureSlice from "@/hooks/lecture/useFirebaseLectureSlice";
 
 const LinkModal: React.FC = () => {
   const dispatch = useDispatch();
-  const { modalRole, handleModalMove } = useClassroomModal();
   const { externalLink } = useLectureInfo();
-  const MODAL_ROLE_OBJ: { [key: string]: string } = {
-    create: "링크 만들기",
-    edit: "수정하기",
-  };
   const handleInputContent = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(setExternalLink(e.target.value));
   };
@@ -22,19 +16,7 @@ const LinkModal: React.FC = () => {
 
   return (
     <Layout>
-      <ModalHeader currentModalName={MODAL_ROLE_OBJ[modalRole]}>
-        {modalRole === "create" ? (
-          <button
-            onClick={() =>
-              handleModalMove("lectureTypeModalOpen", "linkModalOpen")
-            }
-          >
-            강의 만들기
-          </button>
-        ) : (
-          <span>강의 수정</span>
-        )}
-      </ModalHeader>
+      <ModalHeader currentModalName="linkModalOpen" />
       <ModalMain>
         <label htmlFor="externalLink" className="hidden" />
         <input

--- a/src/app/classroom/(components)/modal/createLecture/MakeLectureModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/MakeLectureModal.tsx
@@ -35,7 +35,7 @@ const MakeLectureModal: React.FC = () => {
   return (
     <Layout>
       <div className="flex flex-col gap-[26px]">
-        <ModalHeader currentModalName={"강의 만들기"} />
+        <ModalHeader />
         <div className="flex justify-between">
           <div
             className={`flex flex-col items-center justify-center 1013

--- a/src/app/classroom/(components)/modal/createLecture/NoteModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/NoteModal.tsx
@@ -2,7 +2,6 @@ import dynamic from "next/dynamic";
 import Layout from "../common/Layout";
 import ModalHeader from "../common/ModalHeader";
 import ModalMain from "../common/ModalMain";
-import useClassroomModal from "@/hooks/lecture/useClassroomModal";
 import useFirebaseLectureSlice from "@/hooks/lecture/useFirebaseLectureSlice";
 
 const NoSsrEditor = dynamic(() => import("./NoteSection"), {
@@ -11,28 +10,11 @@ const NoSsrEditor = dynamic(() => import("./NoteSection"), {
 });
 
 const NoteModal: React.FC = () => {
-  const { modalRole, handleModalMove } = useClassroomModal();
   useFirebaseLectureSlice();
-  const MODAL_ROLE_OBJ: { [key: string]: string } = {
-    create: "노트 만들기",
-    edit: "수정하기",
-  };
 
   return (
     <Layout>
-      <ModalHeader currentModalName={MODAL_ROLE_OBJ[modalRole]}>
-        {modalRole === "create" ? (
-          <button
-            onClick={() =>
-              handleModalMove("lectureTypeModalOpen", "noteModalOpen")
-            }
-          >
-            강의 만들기
-          </button>
-        ) : (
-          <span>강의 수정</span>
-        )}
-      </ModalHeader>
+      <ModalHeader currentModalName="noteModalOpen" />
       <ModalMain>
         <NoSsrEditor />
       </ModalMain>

--- a/src/app/classroom/(components)/modal/createLecture/VideoFileModal.tsx
+++ b/src/app/classroom/(components)/modal/createLecture/VideoFileModal.tsx
@@ -28,12 +28,7 @@ const VideoFileModal: React.FC = () => {
   const successMessage = useSelector(
     (state: RootState) => state.dropzoneFile.successMessage,
   );
-  const { modalRole, handleModalMove } = useClassroomModal();
   const { handleRemoveVideoFile } = useVideoFileDrop();
-  const MODAL_ROLE_OBJ: { [key: string]: string } = {
-    create: "영상 강의 만들기",
-    edit: "수정하기",
-  };
 
   useEffect(() => {
     if (videoFileName) {
@@ -48,19 +43,7 @@ const VideoFileModal: React.FC = () => {
 
   return (
     <Layout>
-      <ModalHeader currentModalName={MODAL_ROLE_OBJ[modalRole]}>
-        {modalRole === "create" ? (
-          <button
-            onClick={() =>
-              handleModalMove("lectureTypeModalOpen", "videoFileModalOpen")
-            }
-          >
-            강의 만들기
-          </button>
-        ) : (
-          <span>강의 수정</span>
-        )}
-      </ModalHeader>
+      <ModalHeader currentModalName="videoFileModalOpen" />
       <ModalMain>
         <div className="flex flex-col gap-5 h-72">
           {videoFileName && (

--- a/src/hooks/lecture/useFirebaseLectureSlice.ts
+++ b/src/hooks/lecture/useFirebaseLectureSlice.ts
@@ -38,7 +38,7 @@ const useFirebaseLectureSlice = () => {
           .split("?")[0]
           .split("/");
         const filePath = decodeURIComponent(urlParts[urlParts.length - 1]);
-        const fileName = filePath.split("/")[2];
+        const fileName = filePath.split("/")[3];
         dispatch(setVideoFileName(fileName));
         dispatch(
           setErrorMessage(

--- a/src/hooks/lecture/useUploadVideo.ts
+++ b/src/hooks/lecture/useUploadVideo.ts
@@ -12,6 +12,7 @@ import {
   setSuccessMessage,
   setVideoFileName,
 } from "@/redux/slice/dropzoneFileSlice";
+import { v4 as uuidv4 } from "uuid";
 
 const useUploadVideo = () => {
   const dispatch = useDispatch();
@@ -35,11 +36,13 @@ const useUploadVideo = () => {
       dispatch(setVideoLength(formattedTime));
     };
   };
-
   const onUploadVideo = (uploadFile: File) => {
     try {
       const storageRef = ref(storage);
-      const fileRef = ref(storageRef, `lectures/videos/${uploadFile.name}`);
+      const fileRef = ref(
+        storageRef,
+        `lectures/videos/${uuidv4()}/${uploadFile.name}`,
+      );
       const uploadTask = uploadBytesResumable(fileRef, uploadFile);
 
       uploadTask.on(


### PR DESCRIPTION
## 개요 :mag:
* 노트/링크/비디오파일에서 겹치는 브래드크럼을 `ModalHeader.tsx`로 합침
* 브래드크럼에서 사용한 화살표 아이콘을 `before` 가상 요소가 아닌 `Image` 컴포넌트를 사용하여 웹접근성 향상
* 비디오 파일을 저장할때, 중복되는 비디오 파일은 1개만 저장됨. 이로인해 여러강의에서 같은 영상파일을 업로드했을 경우
한곳에서만 삭제해도 다른강의에서 문제가 발생함. 
이에 대한 해결책으로 비디오파일 저장시 uuid를 이용하여 랜덤 폴더를 생성하고, 해당위치에 비디오 파일을 저장할 수 있도록 보안을 강화함

## 작업사항 :memo:
* close #390 
* close #391

